### PR TITLE
ci: remove recursive flag for isort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Check Python code import statements
         run: |
-          isort -rc . --check --diff
+          isort . --check --diff
 
 
   test:


### PR DESCRIPTION
As of isort 5.0.0, the `-rc` flag (recursive) is deprecated / redundant as this behaviour is now provided by default.

I noticed the warning during your demo - this is something that was carried through from https://github.com/linz/template-python-hello-world  which has since been fixed up on other repos that started with the same template.