### PR TITLE
tests: Avoid intermittent coverage reduction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ line-length = 100
 exclude_lines = [
     'if TYPE_CHECKING:',
     'if __name__ == "__main__":',
+    'pragma: no cover',
 ]
 fail_under = 100
 

--- a/tests/aws_utils.py
+++ b/tests/aws_utils.py
@@ -303,10 +303,10 @@ def wait_for_s3_key(bucket_name: str, key: str, s3_client: S3Client) -> None:
 
     process_timeout = datetime.now() + timedelta(minutes=3)
     while CONTENTS_KEY not in s3_client.list_objects(Bucket=bucket_name, Prefix=key):
-        assert (
+        assert (  # pragma: no cover
             datetime.now() < process_timeout
         ), f"S3 file '{bucket_name}/{key}' was not created, process timed out."
-        time.sleep(5)
+        time.sleep(5)  # pragma: no cover
 
 
 def delete_s3_key(bucket_name: str, key: str, s3_client: S3Client) -> None:
@@ -395,11 +395,11 @@ def wait_for_s3_batch_job_completion(
         )
     )["Job"]["Status"] not in S3_BATCH_JOB_FINAL_STATES:
 
-        assert (
+        assert (  # pragma: no cover
             datetime.now() < process_timeout
         ), f"S3 Batch process {job_result['Job']['JobId']} hasn't completed, process timed out."
 
-        time.sleep(5)
+        time.sleep(5)  # pragma: no cover
 
     assert job_result["Job"]["Status"] == S3_BATCH_JOB_COMPLETED_STATE, job_result
 

--- a/tests/test_processing_stack.py
+++ b/tests/test_processing_stack.py
@@ -230,8 +230,10 @@ class TestWithStagingBucket:
                             executionArn=json_resp[BODY_KEY][EXECUTION_ARN_KEY]
                         )
                     )["status"] == "RUNNING":
-                        LOGGER.info("Polling for State Machine state %s", "." * 6)
-                        time.sleep(5)
+                        LOGGER.info(  # pragma: no cover
+                            "Polling for State Machine state %s", "." * 6
+                        )
+                        time.sleep(5)  # pragma: no cover
 
                     assert execution["status"] == "SUCCEEDED", execution
 
@@ -371,8 +373,10 @@ class TestWithStagingBucket:
                             executionArn=json_resp[BODY_KEY][EXECUTION_ARN_KEY]
                         )
                     )["status"] == "RUNNING":
-                        LOGGER.info("Polling for State Machine state %s", "." * 6)
-                        time.sleep(5)
+                        LOGGER.info(  # pragma: no cover
+                            "Polling for State Machine state %s", "." * 6
+                        )
+                        time.sleep(5)  # pragma: no cover
 
                 assert (execution_output := execution.get("output")), execution
 
@@ -484,8 +488,10 @@ class TestWithStagingBucket:
                         executionArn=state_machine_arn
                     )
                 )["status"] == "RUNNING":
-                    LOGGER.info("Polling for State Machine %s state", state_machine_arn)
-                    time.sleep(5)
+                    LOGGER.info(  # pragma: no cover
+                        "Polling for State Machine %s state", state_machine_arn
+                    )
+                    time.sleep(5)  # pragma: no cover
 
                 assert execution["status"] == "SUCCEEDED", execution
 


### PR DESCRIPTION
Lines which may never be reached for good reasons need to be marked as
such, otherwise we'll get intermittent loss of code coverage when the
loop ends early.

See for example https://github.com/linz/geostore/runs/2740976630?check_suite_focus=true

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
