### PR TITLE
chore: Bump Poetry installer hash

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update --quiet --quiet \
     && rm -rf /var/lib/apt/lists/*
 # hadolint ignore=DL3059
 RUN curl --location --show-error --silent --output get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py \
-    && echo '6e0b57c76d27e3bea0ad12db7bb8cc4c6eabb7dad361bf6180441253d6bd383c get-poetry.py' > get-poetry.py.sha256 \
+    && echo '86aeebaa16fabfecfccea823b6c587aa5055be70da299b7e76578e8df78cd016 get-poetry.py' > get-poetry.py.sha256 \
     && sha256sum --check get-poetry.py.sha256 \
     && python3 get-poetry.py > /dev/null \
     && rm get-poetry.py get-poetry.py.sha256


### PR DESCRIPTION
Verified its history
<https://github.com/python-poetry/poetry/commits/master/get-poetry.py>
and generated hash using `curl
https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
| sha256sum`.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
