### PR TITLE
tests: Make sure to check against all expected items

### DIFF
--- a/tests/test_check_stac_metadata.py
+++ b/tests/test_check_stac_metadata.py
@@ -393,25 +393,30 @@ def should_insert_asset_urls_and_checksums_into_database(subtests: SubTests) -> 
             )
 
             # Then
-            actual_items = processing_assets_model.query(
+            actual_asset_items = processing_assets_model.query(
                 expected_hash_key,
                 processing_assets_model.sk.startswith(
                     f"{ProcessingAssetType.DATA.value}{DB_KEY_SEPARATOR}"
                 ),
             )
-            for actual_item, expected_item in zip(actual_items, expected_asset_items):
-                with subtests.test():
-                    assert actual_item.attribute_values == expected_item.attribute_values
+            for expected_item in expected_asset_items:
+                with subtests.test(msg=f"Asset {expected_item.pk}"):
+                    assert (
+                        actual_asset_items.next().attribute_values == expected_item.attribute_values
+                    )
 
-            actual_items = processing_assets_model.query(
+            actual_metadata_items = processing_assets_model.query(
                 expected_hash_key,
                 processing_assets_model.sk.startswith(
                     f"{ProcessingAssetType.METADATA.value}{DB_KEY_SEPARATOR}"
                 ),
             )
-            for actual_item, expected_item in zip(actual_items, expected_metadata_items):
-                with subtests.test():
-                    assert actual_item.attribute_values == expected_item.attribute_values
+            for expected_item in expected_metadata_items:
+                with subtests.test(msg=f"Metadata {expected_item.pk}"):
+                    assert (
+                        actual_metadata_items.next().attribute_values
+                        == expected_item.attribute_values
+                    )
 
 
 @patch("backend.check_stac_metadata.task.STACDatasetValidator.validate")


### PR DESCRIPTION
`zip` will stop emitting entries once one of the lists have been
exhausted, meaning we might not have tested with all of the expected
entries if the actual entries list was shorter.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
