### PR TITLE
fix: Allow staging users role assumption only by main principal

### DIFF
--- a/infrastructure/constructs/processing.py
+++ b/infrastructure/constructs/processing.py
@@ -387,9 +387,7 @@ class Processing(Construct):
         staging_users_role = aws_iam.Role(
             self,
             "staging-users-role",
-            assumed_by=aws_iam.CompositePrincipal(  # type: ignore[arg-type]
-                principal, aws_iam.ServicePrincipal("batchoperations.s3.amazonaws.com")
-            ),
+            assumed_by=principal,  # type: ignore[arg-type]
             max_session_duration=MAX_SESSION_DURATION,
             role_name=ResourceName.STAGING_USERS_ROLE_NAME.value,
         )


### PR DESCRIPTION
Allowing the S3 Batch Operations service was not necessary after all,
and caused non-prod deployment to hit a known CDK limitation
<https://github.com/aws/aws-cdk/issues/1578>.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
