### PR TITLE
fix: Move staging back to top level

### DIFF
--- a/infrastructure/application_stack.py
+++ b/infrastructure/application_stack.py
@@ -11,6 +11,7 @@ from .constructs.lambda_layers import LambdaLayers
 from .constructs.lds import LDS
 from .constructs.opentopo import OpenTopography
 from .constructs.processing import Processing
+from .constructs.staging import Staging
 from .constructs.storage import Storage
 
 
@@ -49,6 +50,7 @@ class Application(Stack):
             storage_bucket=storage.storage_bucket,
             validation_results_table=storage.validation_results_table,
         )
+        Staging(self, "staging", users_role=processing.staging_users_role)
 
         API(
             self,

--- a/infrastructure/constructs/processing.py
+++ b/infrastructure/constructs/processing.py
@@ -43,7 +43,6 @@ from .lambda_config import LAMBDA_TIMEOUT
 from .lambda_task import LambdaTask
 from .roles import MAX_SESSION_DURATION
 from .s3_policy import ALLOW_DESCRIBE_ANY_S3_JOB
-from .staging import Staging
 from .sts_policy import ALLOW_ASSUME_ANY_ROLE
 from .table import Table
 
@@ -384,14 +383,13 @@ class Processing(Construct):
         ############################################################################################
         # STAGING BUCKET ACCESS
 
-        staging_users_role = aws_iam.Role(
+        self.staging_users_role = aws_iam.Role(
             self,
             "staging-users-role",
             assumed_by=principal,  # type: ignore[arg-type]
             max_session_duration=MAX_SESSION_DURATION,
             role_name=ResourceName.STAGING_USERS_ROLE_NAME.value,
         )
-        Staging(self, "staging", users_role=staging_users_role)
 
         ############################################################################################
         # GENERIC_TASKS


### PR DESCRIPTION
Should ensure that its logical ID
<https://docs.aws.amazon.com/cdk/latest/guide/identifiers.html> stays
the same.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
