### PR TITLE
feat: Create and archive JUnit report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,8 +131,15 @@ jobs:
 
       - name: Run infrastructure tests online
         run: >
-          poetry run coverage run --append --module pytest -m infrastructure
+          poetry run coverage run --append --module pytest --junitxml=junit.xml
           "--randomly-seed=${GITHUB_RUN_ID}" --verbosity=2 tests
+
+      - name: Archive JUnit test report
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-report
+          path: junit.xml
+        if: ${{ failure() }}
 
       - name: Verify test coverage
         run: |


### PR DESCRIPTION
Only archive it in case of test failure.

This should allow closer inspection of test result details on failure.

To avoid having to merge two reports, we now run the non-infrastructure
tests *twice,* first to verify that none of them use `socket`, and
second to generate the full test report. This should be fine since they
only take a second or two to run.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
