### PR TITLE
fix: handle step function returning null on failure

### DIFF
--- a/backend/notify_status_update/task.py
+++ b/backend/notify_status_update/task.py
@@ -12,12 +12,15 @@ from ..api_keys import EVENT_KEY
 from ..aws_message_attributes import DATA_TYPE_STRING
 from ..log import set_up_logging
 from ..parameter_store import ParameterName, get_param
+from ..step_function import get_import_status_given_arn
 from ..step_function_keys import (
     ASSET_UPLOAD_KEY,
     DATASET_PREFIX_KEY,
+    JOB_STATUS_SUCCEEDED,
     METADATA_UPLOAD_KEY,
     NEW_VERSION_S3_LOCATION,
     STATUS_KEY,
+    UPDATE_DATASET_KEY,
     VALIDATION_KEY,
     VERSION_ID_KEY,
 )
@@ -44,8 +47,6 @@ STEP_FUNCTION_ARN_KEY = "executionArn"
 STEP_FUNCTION_INPUT_KEY = "input"
 STEP_FUNCTION_OUTPUT_KEY = "output"
 STEP_FUNCTION_STARTDATE_KEY = "startDate"
-STEP_FUNCTION_UPLOAD_STATUS_KEY = "upload_status"
-STEP_FUNCTION_UPDATE_DATASET_KEY = "update_dataset_catalog"
 STEP_FUNCTION_STOPDATE_KEY = "stopDate"
 
 WEBHOOK_MESSAGE_BLOCKS_KEY = "blocks"
@@ -85,9 +86,7 @@ def publish_sns_message(event: JsonObject) -> None:
 def post_to_slack(event: JsonObject) -> None:
     event_details = event[EVENT_DETAIL_KEY]
     step_function_input = loads(event_details[STEP_FUNCTION_INPUT_KEY])
-    step_function_output = loads(event_details[STEP_FUNCTION_OUTPUT_KEY])
-    validation_details = step_function_output[STEP_FUNCTION_UPLOAD_STATUS_KEY]
-    s3_location = step_function_output[STEP_FUNCTION_UPDATE_DATASET_KEY][NEW_VERSION_S3_LOCATION]
+    validation_details = get_import_status_given_arn(event_details[STEP_FUNCTION_ARN_KEY])
 
     running_time = str(
         datetime.fromtimestamp(event_details[STEP_FUNCTION_STOPDATE_KEY] / 1000)
@@ -108,13 +107,17 @@ def post_to_slack(event: JsonObject) -> None:
         blocks.SectionBlock(text=f"*Running Time:* {running_time}"),
         blocks.DividerBlock(),
         blocks.SectionBlock(
-            text=f"*Validation:* `{dumps(validation_details[VALIDATION_KEY])}`\n"
-            f"*Asset Upload:* `{dumps(validation_details[ASSET_UPLOAD_KEY])}`\n"
-            f"*Metadata Upload:* `{dumps(validation_details[METADATA_UPLOAD_KEY])}`"
+            text=f"*Validation:* `{validation_details[VALIDATION_KEY]}`\n"
+            f"*Asset Upload:* `{validation_details[ASSET_UPLOAD_KEY]}`\n"
+            f"*Metadata Upload:* `{validation_details[METADATA_UPLOAD_KEY]}`"
         ),
-        blocks.DividerBlock(),
-        blocks.SectionBlock(text=f"*S3 Location:* `{s3_location}`"),
     ]
+
+    if event_details[STATUS_KEY] == JOB_STATUS_SUCCEEDED:
+        step_function_output = loads(event_details[STEP_FUNCTION_OUTPUT_KEY])
+        s3_location = step_function_output[UPDATE_DATASET_KEY][NEW_VERSION_S3_LOCATION]
+        slack_message_blocks.append(blocks.DividerBlock())
+        slack_message_blocks.append(blocks.SectionBlock(text=f"*S3 Location:* `{s3_location}`"))
 
     response = WebhookClient(environ[SLACK_URL_ENV_NAME]).send(blocks=slack_message_blocks)
     assert response.status_code == HTTPStatus.OK

--- a/backend/step_function_keys.py
+++ b/backend/step_function_keys.py
@@ -1,3 +1,4 @@
+JOB_STATUS_FAILED = "FAILED"
 JOB_STATUS_RUNNING = "RUNNING"
 JOB_STATUS_SUCCEEDED = "SUCCEEDED"
 
@@ -22,5 +23,7 @@ S3_ROLE_ARN_KEY = "s3_role_arn"
 STATUS_KEY = "status"
 STEP_FUNCTION_KEY = "step_function"
 TITLE_KEY = "title"
+UPDATE_DATASET_KEY = "update_dataset_catalog"
+UPLOAD_STATUS_KEY = "upload_status"
 VALIDATION_KEY = "validation"
 VERSION_ID_KEY = "version_id"

--- a/infrastructure/application_stack.py
+++ b/infrastructure/application_stack.py
@@ -74,6 +74,7 @@ class Application(Stack):
             botocore_lambda_layer=lambda_layers.botocore,
             env_name=env_name,
             state_machine=processing.state_machine,
+            validation_results_table=storage.validation_results_table,
         )
 
         if self.node.try_get_context("enableLDSAccess"):

--- a/infrastructure/constructs/processing.py
+++ b/infrastructure/constructs/processing.py
@@ -30,6 +30,8 @@ from backend.step_function_keys import (
     METADATA_UPLOAD_KEY,
     METADATA_URL_KEY,
     S3_ROLE_ARN_KEY,
+    UPDATE_DATASET_KEY,
+    UPLOAD_STATUS_KEY,
     VALIDATION_KEY,
     VERSION_ID_KEY,
 )
@@ -309,7 +311,7 @@ class Processing(Construct):
             "upload-status",
             directory="upload_status",
             botocore_lambda_layer=botocore_lambda_layer,
-            result_path="$.upload_status",
+            result_path=f"$.{UPLOAD_STATUS_KEY}",
             extra_environment={ENV_NAME_VARIABLE_NAME: env_name},
         )
         validation_results_table.grant_read_data(upload_status_task.lambda_function)
@@ -347,6 +349,7 @@ class Processing(Construct):
             directory="update_dataset_catalog",
             botocore_lambda_layer=botocore_lambda_layer,
             extra_environment={ENV_NAME_VARIABLE_NAME: env_name},
+            result_path=f"$.{UPDATE_DATASET_KEY}",
         )
         self.message_queue.grant_send_messages(update_dataset_catalog.lambda_function)
 

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -20,20 +20,25 @@ from backend.notify_status_update.task import (
     STEP_FUNCTION_OUTPUT_KEY,
     STEP_FUNCTION_STARTDATE_KEY,
     STEP_FUNCTION_STOPDATE_KEY,
-    STEP_FUNCTION_UPDATE_DATASET_KEY,
-    STEP_FUNCTION_UPLOAD_STATUS_KEY,
     WEBHOOK_MESSAGE_BLOCKS_KEY,
     lambda_handler,
     publish_sns_message,
 )
+from backend.step_function import Outcome
 from backend.step_function_keys import (
     ASSET_UPLOAD_KEY,
     DATASET_ID_KEY,
     DATASET_PREFIX_KEY,
+    ERRORS_KEY,
+    JOB_STATUS_FAILED,
+    JOB_STATUS_RUNNING,
     JOB_STATUS_SUCCEEDED,
     METADATA_UPLOAD_KEY,
     NEW_VERSION_S3_LOCATION,
     STATUS_KEY,
+    STEP_FUNCTION_KEY,
+    UPDATE_DATASET_KEY,
+    UPLOAD_STATUS_KEY,
     VALIDATION_KEY,
     VERSION_ID_KEY,
 )
@@ -44,10 +49,21 @@ from .stac_generators import any_dataset_id, any_dataset_prefix, any_dataset_ver
 
 
 @patch("backend.notify_status_update.task.WebhookClient.send")
-def should_notify_slack_with_finished_details_when_url_set(webhook_client_mock: MagicMock) -> None:
+@patch("backend.notify_status_update.task.get_import_status_given_arn")
+def should_notify_slack_with_finished_details_when_url_set(
+    step_func_status_mock: MagicMock, webhook_client_mock: MagicMock
+) -> None:
     # Given
 
     webhook_client_mock.return_value.status_code = HTTPStatus.OK
+
+    step_func_status_mock.return_value = {
+        STEP_FUNCTION_KEY: {STATUS_KEY: JOB_STATUS_SUCCEEDED},
+        VALIDATION_KEY: {STATUS_KEY: Outcome.SKIPPED.value, ERRORS_KEY: []},
+        METADATA_UPLOAD_KEY: {STATUS_KEY: Outcome.SKIPPED.value, ERRORS_KEY: []},
+        ASSET_UPLOAD_KEY: {STATUS_KEY: Outcome.SKIPPED.value, ERRORS_KEY: []},
+    }
+
     mock_slack_url = any_https_url()
 
     with patch.dict(environ, {SLACK_URL_ENV_NAME: mock_slack_url}), patch(
@@ -68,12 +84,12 @@ def should_notify_slack_with_finished_details_when_url_set(webhook_client_mock: 
                 ),
                 STEP_FUNCTION_OUTPUT_KEY: dumps(
                     {
-                        STEP_FUNCTION_UPLOAD_STATUS_KEY: {
+                        UPLOAD_STATUS_KEY: {
                             VALIDATION_KEY: "",
                             ASSET_UPLOAD_KEY: "",
                             METADATA_UPLOAD_KEY: "",
                         },
-                        STEP_FUNCTION_UPDATE_DATASET_KEY: {NEW_VERSION_S3_LOCATION: any_s3_url()},
+                        UPDATE_DATASET_KEY: {NEW_VERSION_S3_LOCATION: any_s3_url()},
                     }
                 ),
                 STEP_FUNCTION_STARTDATE_KEY: round(
@@ -95,6 +111,7 @@ def should_not_notify_slack_when_step_function_running(webhook_client_mock: Magi
     # Given
 
     webhook_client_mock.return_value.status_code = HTTPStatus.OK
+
     mock_slack_url = any_https_url()
 
     with patch.dict(environ, {SLACK_URL_ENV_NAME: mock_slack_url}), patch(
@@ -103,6 +120,7 @@ def should_not_notify_slack_when_step_function_running(webhook_client_mock: Magi
         # When
         notify_status_update_input = {
             EVENT_DETAIL_KEY: {
+                STATUS_KEY: JOB_STATUS_RUNNING,
                 STEP_FUNCTION_STOPDATE_KEY: None,
             }
         }
@@ -111,6 +129,54 @@ def should_not_notify_slack_when_step_function_running(webhook_client_mock: Magi
 
         # Then
         webhook_client_mock.assert_not_called()
+
+
+@patch("backend.notify_status_update.task.WebhookClient.send")
+@patch("backend.notify_status_update.task.get_import_status_given_arn")
+def should_not_notify_slack_when_step_function_failed(
+    step_func_status_mock: MagicMock, webhook_client_mock: MagicMock
+) -> None:
+    # Given
+
+    webhook_client_mock.return_value.status_code = HTTPStatus.OK
+    mock_slack_url = any_https_url()
+    now_ts = datetime.now()
+
+    step_func_status_mock.return_value = {
+        STEP_FUNCTION_KEY: {STATUS_KEY: JOB_STATUS_FAILED},
+        VALIDATION_KEY: {STATUS_KEY: Outcome.SKIPPED.value, ERRORS_KEY: []},
+        METADATA_UPLOAD_KEY: {STATUS_KEY: Outcome.SKIPPED.value, ERRORS_KEY: []},
+        ASSET_UPLOAD_KEY: {STATUS_KEY: Outcome.SKIPPED.value, ERRORS_KEY: []},
+    }
+
+    with patch.dict(environ, {SLACK_URL_ENV_NAME: mock_slack_url}), patch(
+        "backend.notify_status_update.task.publish_sns_message"
+    ):
+        # When
+        notify_status_update_input = {
+            EVENT_DETAIL_KEY: {
+                STATUS_KEY: JOB_STATUS_FAILED,
+                STEP_FUNCTION_ARN_KEY: any_arn_formatted_string(),
+                STEP_FUNCTION_INPUT_KEY: dumps(
+                    {
+                        DATASET_ID_KEY: any_dataset_id(),
+                        DATASET_PREFIX_KEY: any_dataset_prefix(),
+                        VERSION_ID_KEY: any_dataset_version_id(),
+                    }
+                ),
+                STEP_FUNCTION_STARTDATE_KEY: round(
+                    (now_ts - timedelta(seconds=10)).timestamp() * 1000
+                ),
+                STEP_FUNCTION_STOPDATE_KEY: round(now_ts.timestamp() * 1000),
+            },
+            STEP_FUNCTION_OUTPUT_KEY: None,
+        }
+
+        lambda_handler(notify_status_update_input, any_lambda_context())
+
+        # Then
+        webhook_client_mock.assert_called_once()
+        assert len(webhook_client_mock.call_args[1][WEBHOOK_MESSAGE_BLOCKS_KEY]) == 9
 
 
 @patch("backend.notify_status_update.task.WebhookClient.send")

--- a/tests/test_notify_slack.py
+++ b/tests/test_notify_slack.py
@@ -47,18 +47,13 @@ from .aws_utils import any_arn_formatted_string, any_lambda_context, any_s3_url
 from .general_generators import any_https_url
 from .stac_generators import any_dataset_id, any_dataset_prefix, any_dataset_version_id
 
-STEP_FUNCTION_START_DATE = round(
+STEP_FUNCTION_START_MILLISECOND_TIMESTAMP = round(
     datetime(
         2001, 2, 3, hour=4, minute=5, second=6, microsecond=789876, tzinfo=timezone.utc
     ).timestamp()
     * 1000
 )
-STEP_FUNCTION_STOPDATE = round(
-    datetime(
-        2001, 2, 3, hour=4, minute=5, second=16, microsecond=789876, tzinfo=timezone.utc
-    ).timestamp()
-    * 1000
-)
+STEP_FUNCTION_STOP_MILLISECOND_TIMESTAMP = STEP_FUNCTION_START_MILLISECOND_TIMESTAMP + 10
 
 
 @patch("backend.notify_status_update.task.WebhookClient.send")
@@ -104,8 +99,8 @@ def should_notify_slack_with_finished_details_when_url_set(
                         UPDATE_DATASET_KEY: {NEW_VERSION_S3_LOCATION: any_s3_url()},
                     }
                 ),
-                STEP_FUNCTION_STARTDATE_KEY: STEP_FUNCTION_START_DATE,
-                STEP_FUNCTION_STOPDATE_KEY: STEP_FUNCTION_STOPDATE,
+                STEP_FUNCTION_STARTDATE_KEY: STEP_FUNCTION_START_MILLISECOND_TIMESTAMP,
+                STEP_FUNCTION_STOPDATE_KEY: STEP_FUNCTION_STOP_MILLISECOND_TIMESTAMP,
             }
         }
 
@@ -173,8 +168,8 @@ def should_notify_slack_when_step_function_failed(
                         VERSION_ID_KEY: any_dataset_version_id(),
                     }
                 ),
-                STEP_FUNCTION_STARTDATE_KEY: STEP_FUNCTION_START_DATE,
-                STEP_FUNCTION_STOPDATE_KEY: STEP_FUNCTION_STOPDATE,
+                STEP_FUNCTION_STARTDATE_KEY: STEP_FUNCTION_START_MILLISECOND_TIMESTAMP,
+                STEP_FUNCTION_STOPDATE_KEY: STEP_FUNCTION_STOP_MILLISECOND_TIMESTAMP,
             },
             STEP_FUNCTION_OUTPUT_KEY: None,
         }


### PR DESCRIPTION
Didn't realise that the step function "output" is null when it fails - have to pull or generate data from elsewhere to allow failures to still show validation results etc. 
