### PR TITLE
feat: Use new Poetry installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,16 +84,16 @@ One-time setup, assuming you are in the project directory:
    1. Install:
 
       ```bash
-      curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+      curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python -
       ```
 
-   1. Add the following to ~/.bashrc:
+   1. Make sure `"${HOME}/.local/bin"` is on your `PATH`, for example by adding the following to
+      your `~/.bashrc`:
 
       ```bash
-      # Poetry <https://python-poetry.org/>
-      if [[ -e "${HOME}/.poetry" ]]
+      if [[ -e "${HOME}/.local/bin" ]]
       then
-          PATH="${HOME}/.poetry/bin:${PATH}"
+          PATH="${HOME}/.local/bin:${PATH}"
       fi
       ```
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,15 +5,15 @@ RUN apt-get update --quiet --quiet \
     curl python3-pip > /dev/null \
     && rm -rf /var/lib/apt/lists/*
 # hadolint ignore=DL3059
-RUN curl --location --show-error --silent --output get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py \
-    && echo '86aeebaa16fabfecfccea823b6c587aa5055be70da299b7e76578e8df78cd016 get-poetry.py' > get-poetry.py.sha256 \
-    && sha256sum --check get-poetry.py.sha256 \
-    && python3 get-poetry.py > /dev/null \
-    && rm get-poetry.py get-poetry.py.sha256
+RUN curl --location --show-error --silent --output install-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py \
+    && echo 'b35d059be6f343ac1f05ae56e8eaaaebb34da8c92424ee00133821d7f11e3a9c install-poetry.py' > install-poetry.py.sha256 \
+    && sha256sum --check install-poetry.py.sha256 \
+    && python3 install-poetry.py > /dev/null \
+    && rm install-poetry.py install-poetry.py.sha256
 COPY poetry.lock poetry.toml pyproject.toml /opt/
 WORKDIR /opt
 ARG task
-RUN ~/.poetry/bin/poetry install --quiet --extras=${task} --no-dev
+RUN ~/.local/bin/poetry install --quiet --extras=${task} --no-dev
 
 
 FROM ubuntu:20.04


### PR DESCRIPTION
The original installer is now deprecated
<https://python-poetry.org/blog/announcing-poetry-1.2.0a1/#deprecation-of-the-get-poetrypy-script>.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
