### PR TITLE
fix: Use correct Python version for virtualenv

### DIFF
--- a/reset-dev-env.bash
+++ b/reset-dev-env.bash
@@ -112,6 +112,7 @@ then
     pyenv install --skip-existing "$(cat .python-version)"
 
     echo "Installing Python packages"
+    poetry env use "$(cat .python-version)"
     poetry install \
         --extras="$(sed --quiet '/\[tool\.poetry\.extras\]/,/^\[/{s/^\(.*\) = \[/\1/p}' pyproject.toml | sed --null-data 's/\n/ /g;s/ $//')" \
         --remove-untracked


### PR DESCRIPTION
Poetry by default just uses the system Python, even if that is not
supported by the version specifier in pyproject.toml. Poetry prints

> The currently activated Python version 3.9.7 is not supported by the
> project (3.8.10).
> Trying to find and use a compatible version.
> Using python3 (3.8.10)

This message is misleading - it still uses the system Python! See
<https://github.com/python-poetry/poetry/issues/655> for details.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
