### PR TITLE
refactor: Run non-infrastructure tests before configuring AWS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,11 @@ jobs:
       - name: Print CDK version
         run: poetry run cdk --version
 
+      - name: Run non-infrastructure tests offline
+        run: >
+          poetry run coverage run --module pytest --disable-socket -m 'not infrastructure'
+          "--randomly-seed=${GITHUB_RUN_ID}" --verbosity=2
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1.5.11
         with:
@@ -126,11 +131,6 @@ jobs:
       - name: Deploy AWS stacks for testing
         run: |
           poetry run cdk deploy --all --require-approval never --strict --change-set-name "ci-${GITHUB_RUN_ID}"
-
-      - name: Run non-infrastructure tests offline
-        run: >
-          poetry run coverage run --module pytest --disable-socket -m 'not infrastructure'
-          "--randomly-seed=${GITHUB_RUN_ID}" --verbosity=2
 
       - name: Run infrastructure tests online
         run: >


### PR DESCRIPTION
This way we can make sure the correct tests are marked as
"infrastructure".

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
