### PR TITLE
feat: Add command-line interface (CLI) 1st increment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          submodules: 'true'
+
+      - id: python-version
+        run: echo "::set-output name=id::$(cat .python-version)"
+
+      - name: Use Python ${{ steps.python-version.outputs.id }}
+        uses: actions/setup-python@v2.2.2
+        with:
+          python-version: ${{ steps.python-version.outputs.id }}
+
+      - name: Cache pip
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.cache/pip
+          key:
+            ${{ runner.os }}-pip-${{ secrets.CACHE_SEED }}-${{ steps.python-version.outputs.id
+            }}-${{ hashFiles('./poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ secrets.CACHE_SEED }}-${{ steps.python-version.outputs.id }}-
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install poetry
+          python -m poetry install --extras=cli --no-root
+
+      - name: Build
+        run: poetry build

--- a/USAGE.md
+++ b/USAGE.md
@@ -117,6 +117,115 @@ Example of AWS service account authentication and authorization in to Geostore u
   export AWS_PROFILE geostore-users
   ```
 
+## Command line
+
+The general synopsis is `geostore NOUN VERB [PARAMETER…]`. `NOUN` is the type of thing the command
+is operating on, for example `version` when dealing with dataset versions. `VERB` is the action it
+is telling the system to take, for example `list` to show a listing of the relevant objects, or
+`create` to create such an object. Verbs may have parameters in the form of key/value pairs.
+`--KEY=VALUE` means the parameter is mandatory, and `[--KEY=VALUE]` means the parameter is optional.
+
+To show the full synopsis, run `geostore --help`.
+
+Each action and its relevant options are explained in the following sections.
+
+### Dataset Space
+
+Synopsis: `geostore dataset VERB [PARAMETER…]`
+
+#### Create
+
+Synopsis: `geostore dataset create --title=TITLE --description=DESCRIPTION`
+
+This creates a new dataset space and prints the new dataset ID on standard output when successful.
+
+Example:
+
+```console
+$ geostore dataset create --title=Auckland_2020 --description='Aerial imagery from April 2020'
+Auckland_2020-01F9ZFRK12V0WFXJ94S0DHCP65
+```
+
+#### List
+
+Synopsis: `geostore dataset list [--id=ID]`
+
+Prints a listing of datasets, optionally filtered by the dataset ID.
+
+Examples:
+
+- List all datasets:
+
+  ```console
+  $ geostore dataset list
+  Dataset ID                                 | Title           | Description
+  Auckland_2020-01F9ZFRK12V0WFXJ94S0DHCP65   | Auckland_2020   | Aerial imagery from April 2020
+  Wellington_2020-01FJJDQJ2X0MPTPYPMM246DSH1 | Wellington_2020 | Aerial imagery from March 2020
+  ```
+
+- Filter to a single dataset:
+
+  ```console
+  $ geostore dataset list --id=Auckland_2020-01F9ZFRK12V0WFXJ94S0DHCP65
+  Dataset ID                               | Title         | Description
+  Auckland_2020-01F9ZFRK12V0WFXJ94S0DHCP65 | Auckland_2020 | Aerial imagery from April 2020
+  ```
+
+#### Delete
+
+Synopsis: `geostore dataset delete --id=ID`
+
+`ID` is the dataset ID.
+
+Deletes a dataset. Will only work if there are no versions in the dataset. This command does not
+print anything when successful.
+
+Example:
+
+```console
+$ geostore dataset delete --id=Auckland_2020-01F9ZFRK12V0WFXJ94S0DHCP65
+```
+
+### Dataset version
+
+Synopsis: `geostore version VERB [PARAMETER…]`
+
+#### Create
+
+Synopsis: `geostore version create --id=ID --s3-role=ROLE_ARN --url=URL`
+
+This creates a new dataset version. It returns immediately, while the import process continues in
+AWS. It prints the new dataset version ID and the ID of the import process on standard output in
+case of success.
+
+Example:
+
+```console
+$ geostore version create --id=Auckland_2020-01F9ZFRK12V0WFXJ94S0DHCP65 --s3-role=arn:aws:iam::1234567890:role/example-role --url='s3://example-bucket/example dataset/collection.json'
+Dataset version ID                        | Import process ID
+2021-07-07T01-46-30-787Z_9NJEAD3VXRCH5W05 | arn:aws:batch:ap-southeast-2:xxxx:job/example-arn
+```
+
+#### Import process status
+
+Synopsis: `geostore version status --id=ID`
+
+`ID` is the import process ID printed by `geostore version create`.
+
+This prints the current status of the dataset version import process started by
+`geostore version create`.
+
+Example:
+
+```console
+$ geostore version status --id=arn:aws:batch:ap-southeast-2:xxxx:job/example-arn
+Validation status: SUCCEEDED
+Metadata upload status: Pending
+Metadata upload errors: None
+Asset upload status: Pending
+Asset upload errors: None
+```
+
 ## Endpoints
 
 There are several end user interaction points in Geostore:

--- a/geostore/cli.py
+++ b/geostore/cli.py
@@ -1,0 +1,64 @@
+import sys
+from enum import IntEnum
+from http import HTTPStatus
+from json import dumps, load
+
+import boto3
+from botocore.exceptions import NoCredentialsError
+from typer import Option, Typer, secho
+from typer.colors import GREEN, RED, YELLOW
+
+from .api_keys import MESSAGE_KEY
+from .aws_keys import BODY_KEY, HTTP_METHOD_KEY
+from .resources import ResourceName
+from .step_function_keys import DATASET_ID_SHORT_KEY, DESCRIPTION_KEY, TITLE_KEY
+
+app = Typer()
+dataset_app = Typer()
+app.add_typer(dataset_app, name="dataset")
+
+
+class ExitCode(IntEnum):
+    SUCCESS = 0
+    UNKNOWN = 1
+    # Exit code 2 is used by Typer to indicate usage error
+    CONFLICT = 3
+    NO_CREDENTIALS = 4
+
+
+@dataset_app.command()
+def create(title: str = Option(...), description: str = Option(...)) -> None:
+    try:
+        client = boto3.client("lambda")
+    except NoCredentialsError:
+        secho(
+            "Unable to locate credentials. Make sure to log in to AWS first.", err=True, fg=YELLOW
+        )
+        sys.exit(ExitCode.NO_CREDENTIALS)
+
+    request_object = {
+        HTTP_METHOD_KEY: "POST",
+        BODY_KEY: {TITLE_KEY: title, DESCRIPTION_KEY: description},
+    }
+    request_payload = dumps(request_object).encode()
+
+    response = client.invoke(
+        FunctionName=ResourceName.DATASETS_ENDPOINT_FUNCTION_NAME.value, Payload=request_payload
+    )
+    response_payload = load(response["Payload"])
+    exit_code = {HTTPStatus.CREATED: ExitCode.SUCCESS, HTTPStatus.CONFLICT: ExitCode.CONFLICT}.get(
+        response_payload["status_code"], ExitCode.UNKNOWN
+    )
+    color = {ExitCode.SUCCESS: GREEN, ExitCode.UNKNOWN: RED}.get(exit_code, YELLOW)
+    response_body = response_payload[BODY_KEY]
+    output = response_body.get(
+        DATASET_ID_SHORT_KEY, response_body.get(MESSAGE_KEY, dumps(response_body))
+    )
+
+    secho(output, err=exit_code != ExitCode.SUCCESS, fg=color)
+
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    app()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1651,7 +1651,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "click"
 version = "8.0.1"
 description = "Composable command line interface toolkit"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -2693,6 +2693,23 @@ ipython-genutils = "*"
 test = ["pytest"]
 
 [[package]]
+name = "typer"
+version = "0.4.0"
+description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+click = ">=7.1.1,<9.0.0"
+
+[package.extras]
+all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)"]
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.4.0,<6.0.0)", "markdown-include (>=0.5.1,<0.6.0)"]
+test = ["shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.910)", "black (>=19.10b0,<20.0b0)", "isort (>=5.0.6,<6.0.0)"]
+
+[[package]]
 name = "types-pkg-resources"
 version = "0.1.3"
 description = "Typing stubs for pkg_resources"
@@ -2830,6 +2847,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 cdk = ["aws-cdk.aws-dynamodb", "aws-cdk.aws-ec2", "aws-cdk.aws-ecr", "aws-cdk.aws-ecr_assets", "aws-cdk.aws-ecs", "aws-cdk.aws-events", "aws-cdk.aws-events-targets", "aws-cdk.aws-iam", "aws-cdk.aws-lambda", "aws-cdk.aws-lambda-event-sources", "aws-cdk.aws-lambda-python", "aws-cdk.aws-s3", "aws-cdk.aws-sns", "aws-cdk.aws-stepfunctions", "aws-cdk.aws-stepfunctions_tasks", "awscli", "cattrs"]
 check_files_checksums = ["boto3", "linz-logger", "multihash", "pynamodb"]
 check_stac_metadata = ["boto3", "jsonschema", "linz-logger", "pynamodb", "strict-rfc3339"]
+cli = ["boto3", "typer"]
 content_iterator = ["jsonschema", "linz-logger", "pynamodb"]
 dataset_versions = ["jsonschema", "linz-logger", "pynamodb", "ulid-py"]
 datasets = ["boto3", "jsonschema", "linz-logger", "pynamodb", "pystac", "ulid-py"]
@@ -2846,7 +2864,7 @@ validation_summary = ["jsonschema", "linz-logger", "pynamodb"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "7f83078cad5d6f1c54c5994ff7055f8ba1b0d11c371e9b454aae48a653aef0de"
+content-hash = "6fec6ad8ae2976a96a75a933b5b03c103b353a30ef4ed8dedb6f0f1cbd6121c2"
 
 [metadata.files]
 appdirs = [
@@ -3719,6 +3737,10 @@ tomlkit = [
 traitlets = [
     {file = "traitlets-5.0.5-py3-none-any.whl", hash = "sha256:69ff3f9d5351f31a7ad80443c2674b7099df13cc41fc5fa6e2f6d3b0330b0426"},
     {file = "traitlets-5.0.5.tar.gz", hash = "sha256:178f4ce988f69189f7e523337a3e11d91c786ded9360174a3d9ca83e79bc5396"},
+]
+typer = [
+    {file = "typer-0.4.0-py3-none-any.whl", hash = "sha256:d81169725140423d072df464cad1ff25ee154ef381aaf5b8225352ea187ca338"},
+    {file = "typer-0.4.0.tar.gz", hash = "sha256:63c3aeab0549750ffe40da79a1b524f60e08a2cbc3126c520ebf2eeaf507f5dd"},
 ]
 types-pkg-resources = [
     {file = "types-pkg_resources-0.1.3.tar.gz", hash = "sha256:834a9b8d3dbea343562fd99d5d3359a726f6bf9d3733bccd2b4f3096fbab9dae"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ pystac = {version = "*", optional = true}
 slack-sdk = {version = "*", extras = ["models", "webhook"], optional = true}
 smart-open = {version = "*", extras = ["s3"], optional = true}
 strict-rfc3339 = {optional = true, version = "*"}
+typer = {version = "*", optional = true}
 ulid-py = {version = "*", optional = true}
 linz-logger = {version = "*", optional = true}
 
@@ -168,6 +169,10 @@ check_stac_metadata = [
     "linz-logger",
     "pynamodb",
     "strict-rfc3339",
+]
+cli = [
+    "boto3",
+    "typer",
 ]
 content_iterator = [
     "jsonschema",
@@ -242,6 +247,9 @@ validation_summary = [
     "linz-logger",
     "pynamodb",
 ]
+
+[tool.poetry.scripts]
+geostore = "geostore.cli:app"
 
 [tool.pylint.MASTER]
 disable = [

--- a/tests/aws_utils.py
+++ b/tests/aws_utils.py
@@ -57,6 +57,8 @@ DELETE_OBJECTS_MAX_KEYS = 1000
 S3_BATCH_JOB_COMPLETED_STATE = "Complete"
 S3_BATCH_JOB_FINAL_STATES = [S3_BATCH_JOB_COMPLETED_STATE, "Failed", "Cancelled"]
 
+LAMBDA_EXECUTED_VERSION = "$LATEST"
+
 
 def any_arn_formatted_string() -> str:
     return f"arn:aws:states:{random_string(5)}:{digits}:execution:yy:xx"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,209 @@
+from http import HTTPStatus
+from io import BytesIO
+from json import dumps, loads
+from unittest.mock import MagicMock, patch
+
+from botocore.exceptions import NoCredentialsError
+from mypy_boto3_lambda.type_defs import InvocationResponseTypeDef
+from mypy_boto3_s3 import S3Client
+from pytest import mark
+from pytest_subtests import SubTests
+from typer.testing import CliRunner
+
+from geostore.aws_keys import BODY_KEY, STATUS_CODE_KEY
+from geostore.cli import app
+from geostore.datasets_model import DATASET_KEY_SEPARATOR
+from geostore.populate_catalog.task import CATALOG_FILENAME
+from geostore.resources import ResourceName
+from geostore.step_function_keys import DATASET_ID_SHORT_KEY
+from geostore.types import JsonObject
+
+from .aws_utils import LAMBDA_EXECUTED_VERSION, delete_s3_key, wait_for_s3_key
+from .general_generators import any_dictionary_key, any_name
+from .stac_generators import any_dataset_description, any_dataset_id, any_dataset_title
+
+CLI_RUNNER = CliRunner(mix_stderr=False)
+
+
+@mark.infrastructure
+def should_create_dataset(s3_client: S3Client) -> None:
+    # When
+    dataset_title = any_dataset_title()
+    result = CLI_RUNNER.invoke(
+        app,
+        [
+            "dataset",
+            "create",
+            f"--title={dataset_title}",
+            f"--description={any_dataset_description()}",
+        ],
+    )
+
+    # Then
+    assert result.exit_code == 0, result
+
+    # Cleanup
+    dataset_id = result.stdout.rstrip()
+    wait_for_s3_key(ResourceName.STORAGE_BUCKET_NAME.value, CATALOG_FILENAME, s3_client)
+    delete_s3_key(
+        ResourceName.STORAGE_BUCKET_NAME.value,
+        f"{dataset_title}{DATASET_KEY_SEPARATOR}{dataset_id}/{CATALOG_FILENAME}",
+        s3_client,
+    )
+    delete_s3_key(ResourceName.STORAGE_BUCKET_NAME.value, CATALOG_FILENAME, s3_client)
+
+
+@mark.infrastructure
+def should_report_duplicate_dataset_title(s3_client: S3Client, subtests: SubTests) -> None:
+    # When
+    dataset_title = any_dataset_title()
+    first_result = CLI_RUNNER.invoke(
+        app,
+        [
+            "dataset",
+            "create",
+            f"--title={dataset_title}",
+            f"--description={any_dataset_description()}",
+        ],
+    )
+    assert first_result.exit_code == 0, first_result
+    dataset_id = first_result.stdout.rstrip()
+
+    duplicate_result = CLI_RUNNER.invoke(
+        app,
+        [
+            "dataset",
+            "create",
+            f"--title={dataset_title}",
+            f"--description={any_dataset_description()}",
+        ],
+    )
+
+    with subtests.test(msg="should print nothing to standard output"):
+        assert duplicate_result.stdout == ""
+
+    with subtests.test(msg="should print payload to standard error"):
+        assert duplicate_result.stderr == f"Conflict: dataset '{dataset_title}' already exists\n"
+
+    with subtests.test(msg="should indicate failure via exit code"):
+        assert duplicate_result.exit_code == 3, duplicate_result
+
+    # Cleanup
+    wait_for_s3_key(ResourceName.STORAGE_BUCKET_NAME.value, CATALOG_FILENAME, s3_client)
+    delete_s3_key(
+        ResourceName.STORAGE_BUCKET_NAME.value,
+        f"{dataset_title}{DATASET_KEY_SEPARATOR}{dataset_id}/{CATALOG_FILENAME}",
+        s3_client,
+    )
+    delete_s3_key(ResourceName.STORAGE_BUCKET_NAME.value, CATALOG_FILENAME, s3_client)
+
+
+@patch("boto3.client")
+def should_report_dataset_creation_success(
+    boto3_client_mock: MagicMock, subtests: SubTests
+) -> None:
+    # Given
+    dataset_id = any_dataset_id()
+    response_payload_object = get_response_object(
+        HTTPStatus.CREATED, {DATASET_ID_SHORT_KEY: dataset_id}
+    )
+    response_payload = BytesIO(initial_bytes=dumps(response_payload_object).encode())
+    boto3_client_mock.return_value.invoke.return_value = InvocationResponseTypeDef(
+        StatusCode=HTTPStatus.OK,
+        FunctionError="",
+        LogResult="",
+        Payload=response_payload,
+        ExecutedVersion=LAMBDA_EXECUTED_VERSION,
+    )
+
+    # When
+    result = CLI_RUNNER.invoke(
+        app,
+        [
+            "dataset",
+            "create",
+            f"--title={any_dataset_title()}",
+            f"--description={any_dataset_description()}",
+        ],
+    )
+
+    # Then
+    with subtests.test(msg="should print response body to standard output"):
+        assert result.stdout == f"{dataset_id}\n"
+
+    with subtests.test(msg="should print nothing to standard error"):
+        assert result.stderr == ""
+
+    with subtests.test(msg="should indicate success via exit code"):
+        assert result.exit_code == 0, result
+
+
+@patch("boto3.client")
+def should_print_error_message_when_authentication_missing(
+    boto3_client_mock: MagicMock, subtests: SubTests
+) -> None:
+    # Given
+    boto3_client_mock.side_effect = NoCredentialsError()
+
+    # When
+    result = CLI_RUNNER.invoke(
+        app,
+        [
+            "dataset",
+            "create",
+            f"--title={any_dataset_title()}",
+            f"--description={any_dataset_description()}",
+        ],
+    )
+
+    # Then
+    with subtests.test(msg="should print nothing to standard output"):
+        assert result.stdout == ""
+
+    with subtests.test(msg="should print error message to standard error"):
+        assert result.stderr == "Unable to locate credentials. Make sure to log in to AWS first.\n"
+
+    with subtests.test(msg="should indicate failure via exit code"):
+        assert result.exit_code == 4, result
+
+
+@patch("boto3.client")
+def should_report_arbitrary_dataset_creation_failure(
+    boto3_client_mock: MagicMock, subtests: SubTests
+) -> None:
+    # Given an arbitrary error
+    response_body = {any_dictionary_key(): any_name()}
+    response_object = get_response_object(HTTPStatus.TOO_MANY_REQUESTS, response_body)
+    response_payload = dumps(response_object).encode()
+    boto3_client_mock.return_value.invoke.return_value = InvocationResponseTypeDef(
+        StatusCode=HTTPStatus.BAD_REQUEST,
+        FunctionError="",
+        LogResult="",
+        Payload=BytesIO(initial_bytes=response_payload),
+        ExecutedVersion=LAMBDA_EXECUTED_VERSION,
+    )
+
+    # When
+    result = CLI_RUNNER.invoke(
+        app,
+        [
+            "dataset",
+            "create",
+            f"--title={any_dataset_title()}",
+            f"--description={any_dataset_description()}",
+        ],
+    )
+
+    # Then
+    with subtests.test(msg="should print nothing to standard output"):
+        assert result.stdout == ""
+
+    with subtests.test(msg="should print response body to standard error"):
+        assert loads(result.stderr) == response_body
+
+    with subtests.test(msg="should indicate failure via exit code"):
+        assert result.exit_code == 1
+
+
+def get_response_object(status_code: int, body: JsonObject) -> JsonObject:
+    return {STATUS_CODE_KEY: status_code, BODY_KEY: body}


### PR DESCRIPTION
## Issues

Contributes towards https://github.com/linz/geospatial-data-lake-team/issues/41.

This only implements a single action, and can be run like `python -m backend.cli dataset create --title=TITLE --description=DESCRIPTION`. This does not include any kind of setup to build and distribute a package to PyPI yet.

## Challenges

- We don't have a common LINZ framework for CLIs, so I've just applied what I consider best practices and documented them in CODING.md

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
