### PR TITLE
fix: Bump Poetry installer checksum in production code

### DIFF
--- a/.github/workflows/prod-upgrade-deploy-test.yml
+++ b/.github/workflows/prod-upgrade-deploy-test.yml
@@ -37,6 +37,13 @@ jobs:
           clean: false
           submodules: true
 
+      # TODO: Remove step once this code is in production
+      - name: Temporarily monkeypatch Poetry installer checksum
+        run:
+          sed -i -e
+          's/86aeebaa16fabfecfccea823b6c587aa5055be70da299b7e76578e8df78cd016/13c8d82f7cd273d0722c1516f99f64f3bcabd5a841587e084f9245db9f703202/'
+          backend/Dockerfile
+
       # TODO: Remove `|| […]` once this code is in production
       - name: Get production configuration
         run: |


### PR DESCRIPTION
Works around the fact that the current production code relies on the
checksum of a third party file which has changed in the meantime.

See for example https://github.com/linz/geostore/runs/4525566154?check_suite_focus=true.

## Issues

Helps with #1287.

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
