### PR TITLE
fix: Add `pip` to the Nix-provided Python environment by means of extraPackages

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -2,9 +2,9 @@
     (
       fetchTarball
         {
-          name = "21.11";
-          url = "https://github.com/NixOS/nixpkgs/archive/a7ecde854aee5c4c7cd6177f54a99d2c1ff28a31.tar.gz";
-          sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
+          name = "nixpkgs-21.11-2022-01-03";
+          url = "https://github.com/NixOS/nixpkgs/archive/08370e1e271f6fe00d302bebbe510fe0e2c611ca.tar.gz";
+          sha256 = "1s9g0vry5jrrvvna250y538i99zy12xy3bs7m3gb4iq64qhyd6bq";
         })
     { }
 }:

--- a/shell.nix
+++ b/shell.nix
@@ -9,10 +9,11 @@
     { }
 }:
 let
+  python = pkgs.python38;
   projectDir = builtins.path { path = ./.; name = "geostore"; };
   nodejsVersion = pkgs.lib.fileContents (projectDir + "/.nvmrc");
   buildNodeJs = pkgs.callPackage "${toString pkgs.path}/pkgs/development/web/nodejs/nodejs.nix" {
-    python = pkgs.python38;
+    inherit python;
   };
   nodejs = buildNodeJs {
     version = nodejsVersion;
@@ -20,8 +21,7 @@ let
   };
 
   poetryEnv = pkgs.poetry2nix.mkPoetryEnv {
-    python = pkgs.python38;
-    inherit projectDir;
+    inherit python projectDir;
     extraPackages = ps: [ ps.pip ];
     overrides = pkgs.poetry2nix.overrides.withoutDefaults (self: super: {
       astroid = super.astroid.overridePythonAttrs (
@@ -106,7 +106,7 @@ pkgs.mkShell {
     pkgs.cargo
     pkgs.nodePackages.aws-azure-login
     (pkgs.poetry.override {
-      python = pkgs.python38;
+      inherit python;
     })
     poetryEnv
   ];

--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,7 @@ let
   poetryEnv = pkgs.poetry2nix.mkPoetryEnv {
     python = pkgs.python38;
     inherit projectDir;
+    extraPackages = ps: [ ps.pip ];
     overrides = pkgs.poetry2nix.overrides.withoutDefaults (self: super: {
       astroid = super.astroid.overridePythonAttrs (
         old: rec {
@@ -104,8 +105,9 @@ pkgs.mkShell {
     nodejs
     pkgs.cargo
     pkgs.nodePackages.aws-azure-login
-    pkgs.python38Packages.pip
-    pkgs.python38Packages.poetry
+    (pkgs.poetry.override {
+      python = pkgs.python38;
+    })
     poetryEnv
   ];
   shellHook = ''


### PR DESCRIPTION
This avoids both Pip and Poetry leaking it's dependencies into the development environment by not setting `$PYTHONPATH` which is done internally in buildPythonPackage and picked up by mkShell.

This is problematic as anything from `$PYTHONPATH` takes precedence over dependencies picked up in Python from `sys.path` in a normal fashion.
Poetry2nix avoids this by creating the environments using `python.withPackages` which is more hermetic than environment variables.

A small demonstration of the issue at play  (note that the correct version of urllib3 from `poetry.lock` as of this commit is `1.26.5`):

- Before this change:
```
$ echo $PYTHONPATH
/nix/store/jxkz72as2q6wiq4crqn47n6wjqfph747-python3.8-pycparser-2.20/lib/python3.8/site-packages:/nix/store/1xsv6ykl54q7107vsyqvd098s740qvkn-python3-3.8.12/lib/python3.8/site-packages:...  # Output truncated as it's full value is not relevant
$ python
Python 3.8.12 (default, Aug 30 2021, 16:42:10)
[GCC 10.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import urllib3
>>> urllib3.__version__
'1.26.7'
```

- After this change
```
$ echo $PYTHONPATH

$ python
Python 3.8.12 (default, Aug 30 2021, 16:42:10)
[GCC 10.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import urllib3
>>> urllib3.__version__
'1.26.5'
```

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
