### PR TITLE
fix: Create Python symlink in project directory

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -110,7 +110,7 @@ pkgs.mkShell {
   ];
   shellHook = ''
         . ${projectDir + "/activate-dev-env.bash"}
-        ln --force --symbolic ${poetryEnv.python.interpreter} ${projectDir}/.run/python
+        ln --force --symbolic ${poetryEnv.python.interpreter} ./.run/python
         cat <<'EOF'
     Welcome to the Geostore development environment!
 


### PR DESCRIPTION
`$projectDir` refers to the Nix store path, which is the wrong place to
create this.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
