### PR TITLE
fix: Remove `NIX_PATH` from `nix-shell` command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -172,4 +172,4 @@ jobs:
           name: linz
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - run: NIX_PATH=channel:nixos-21.05 nix-shell --pure --run true
+      - run: nix-shell --pure --run true


### PR DESCRIPTION
We shouldn't need it anymore since `shell.nix` imports a nixpkgs
archive.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
