### PR TITLE
feat: Install pre-commit dependencies in Nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -103,11 +103,15 @@ in
 pkgs.mkShell {
   buildInputs = [
     nodejs
+    pkgs.cacert
     pkgs.cargo
+    pkgs.docker
+    pkgs.gitFull
     pkgs.nodePackages.aws-azure-login
     (pkgs.poetry.override {
       inherit python;
     })
+    pkgs.which
     poetryEnv
   ];
   shellHook = ''


### PR DESCRIPTION
Enables running `nix-shell --pure --run 'pre-commit run --all-files'`.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
