### PR TITLE
fix: Apply removal policy to log groups

### DIFF
--- a/infrastructure/constructs/api.py
+++ b/infrastructure/constructs/api.py
@@ -14,6 +14,7 @@ from geostore.resources import Resource
 
 from .common import grant_parameter_read_access
 from .lambda_endpoint import LambdaEndpoint
+from .removal_policy import REMOVAL_POLICY
 from .roles import MAX_SESSION_DURATION
 from .s3_policy import ALLOW_DESCRIBE_ANY_S3_JOB
 from .table import Table
@@ -126,6 +127,7 @@ class API(Construct):
                 self,
                 "api-user-log",
                 log_group_name=Resource.CLOUDTRAIL_LOG_GROUP_NAME.resource_name,
+                removal_policy=REMOVAL_POLICY,
             ),  # type: ignore[arg-type]
         )
         trail.add_lambda_event_selector(


### PR DESCRIPTION
This should avoid us ending up with dangling log groups in CI and
development environments, resulting in deployment failures since the
resources already exist.

- [x] Wait for pipeline to succeed
- [x] Manually re-run pipeline
- [x] Verify that the second run succeeds

Closes #1451.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](/linz/geostore/blob/master/CODING.md#Code-review-checklist)
