### PR TITLE
feat: Remove concept of Dataset STAC catalog in geostore

### DIFF
--- a/geostore/aws_message_attributes.py
+++ b/geostore/aws_message_attributes.py
@@ -7,9 +7,6 @@ def decapitalize(key: str) -> str:
     return f"{key[:1].lower()}{key[1:]}"
 
 
-MESSAGE_ATTRIBUTE_TYPE_KEY = "type"
-MESSAGE_ATTRIBUTE_TYPE_ROOT = "root"
-MESSAGE_ATTRIBUTE_TYPE_DATASET = "dataset"
 DATA_TYPE_KEY = "DataType"
 DATA_TYPE_STRING = "String"
 STRING_VALUE_KEY = "StringValue"

--- a/geostore/datasets/create.py
+++ b/geostore/datasets/create.py
@@ -1,38 +1,15 @@
 """Create dataset function."""
 from http import HTTPStatus
-from typing import TYPE_CHECKING
 
-import boto3
 from jsonschema import ValidationError, validate
-from pystac.catalog import Catalog, CatalogType
 from pystac.stac_io import StacIO
 
 from ..api_responses import error_response, success_response
-from ..aws_message_attributes import (
-    DATA_TYPE_STRING,
-    MESSAGE_ATTRIBUTE_TYPE_KEY,
-    MESSAGE_ATTRIBUTE_TYPE_ROOT,
-)
 from ..dataset_properties import TITLE_PATTERN
 from ..datasets_model import datasets_model_with_meta
-from ..parameter_store import ParameterName, get_param
 from ..pystac_io_methods import S3StacIO
-from ..resources import Resource
-from ..s3 import S3_URL_PREFIX
-from ..stac_format import STAC_DESCRIPTION_KEY, STAC_ID_KEY, STAC_TITLE_KEY
 from ..step_function_keys import DESCRIPTION_KEY, TITLE_KEY
 from ..types import JsonObject
-
-if TYPE_CHECKING:
-    # When type checking we want to use the third party package's stub
-    from mypy_boto3_sqs import SQSServiceResource
-    from mypy_boto3_sqs.type_defs import MessageAttributeValueTypeDef
-else:
-    # In production we want to avoid depending on a package which has no runtime impact
-    SQSServiceResource = object  # pragma: no mutate
-    MessageAttributeValueTypeDef = dict  # pragma: no mutate
-
-SQS_RESOURCE: SQSServiceResource = boto3.resource("sqs")
 
 StacIO.set_default(S3StacIO)
 
@@ -65,32 +42,6 @@ def create_dataset(body: JsonObject) -> JsonObject:
     dataset = datasets_model_class(title=dataset_title)
     dataset.save()
     dataset.refresh(consistent_read=True)
-
-    # create dataset catalog
-    dataset_catalog = Catalog(
-        **{
-            STAC_ID_KEY: dataset.dataset_prefix,
-            STAC_DESCRIPTION_KEY: body[DESCRIPTION_KEY],
-            STAC_TITLE_KEY: dataset_title,
-        },
-        catalog_type=CatalogType.SELF_CONTAINED,
-    )
-    dataset_catalog.normalize_hrefs(
-        f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/{dataset.dataset_prefix}"
-    )
-    dataset_catalog.save()
-
-    # add reference to root catalog
-    SQS_RESOURCE.get_queue_by_name(
-        QueueName=get_param(ParameterName.UPDATE_CATALOG_MESSAGE_QUEUE_NAME)
-    ).send_message(
-        MessageBody=dataset.dataset_prefix,
-        MessageAttributes={
-            MESSAGE_ATTRIBUTE_TYPE_KEY: MessageAttributeValueTypeDef(
-                DataType=DATA_TYPE_STRING, StringValue=MESSAGE_ATTRIBUTE_TYPE_ROOT
-            )
-        },
-    )
 
     # return response
     resp_body = dataset.as_dict()

--- a/geostore/populate_catalog/task.py
+++ b/geostore/populate_catalog/task.py
@@ -13,12 +13,6 @@ from pystac.stac_io import StacIO
 
 from ..api_keys import EVENT_KEY
 from ..aws_keys import BODY_KEY
-from ..aws_message_attributes import (
-    MESSAGE_ATTRIBUTE_TYPE_DATASET,
-    MESSAGE_ATTRIBUTE_TYPE_KEY,
-    MESSAGE_ATTRIBUTE_TYPE_ROOT,
-    STRING_VALUE_KEY_LOWER,
-)
 from ..boto3_config import CONFIG
 from ..pystac_io_methods import S3StacIO
 from ..resources import Resource
@@ -57,18 +51,7 @@ def lambda_handler(event: JsonObject, _context: bytes) -> JsonObject:
     LOGGER.debug(dumps({EVENT_KEY: event}))
 
     for message in event[RECORDS_KEY]:
-        if (
-            message[MESSAGE_ATTRIBUTES_KEY][MESSAGE_ATTRIBUTE_TYPE_KEY][STRING_VALUE_KEY_LOWER]
-            == MESSAGE_ATTRIBUTE_TYPE_ROOT
-        ):
-            handle_root(message[BODY_KEY])
-        elif (
-            message[MESSAGE_ATTRIBUTES_KEY][MESSAGE_ATTRIBUTE_TYPE_KEY][STRING_VALUE_KEY_LOWER]
-            == MESSAGE_ATTRIBUTE_TYPE_DATASET
-        ):
-            handle_dataset(message[BODY_KEY])
-        else:
-            raise UnhandledSQSMessageException("Unhandled SQS message type")
+        handle_message(message[BODY_KEY])
 
     return {}
 
@@ -89,35 +72,18 @@ class GeostoreSTACLayoutStrategy(HrefLayoutStrategy):
         return str(item.get_self_href())
 
 
-def handle_dataset(version_metadata_key: str) -> None:
-    """Handle writing a new dataset version to the dataset catalog"""
+def handle_message(version_metadata_key: str) -> None:
+    """Handle writing a new dataset version to the root catalog"""
+
     storage_bucket_path = f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}"
-    dataset_prefix = version_metadata_key.split("/", maxsplit=1)[0]
-    dataset_catalog = Catalog.from_file(
-        f"{storage_bucket_path}/{dataset_prefix}/{CATALOG_FILENAME}"
-    )
 
-    dataset_version_metadata = read_file(f"{storage_bucket_path}/{version_metadata_key}")
-    assert isinstance(dataset_version_metadata, (Catalog, Collection))
-    dataset_catalog.add_child(child=dataset_version_metadata, strategy=GeostoreSTACLayoutStrategy())
-
-    dataset_catalog.normalize_hrefs(
-        f"{storage_bucket_path}/{dataset_prefix}", strategy=GeostoreSTACLayoutStrategy()
-    )
-    dataset_catalog.save(catalog_type=CatalogType.SELF_CONTAINED)
-
-
-def handle_root(dataset_prefix: str) -> None:
-    """Handle writing a new dataset to the root catalog"""
     results = S3_CLIENT.list_objects(
         Bucket=Resource.STORAGE_BUCKET_NAME.resource_name, Prefix=CATALOG_FILENAME
     )
 
     # create root catalog if it doesn't exist
     if CONTENTS_KEY in results:
-        root_catalog = Catalog.from_file(
-            f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/{CATALOG_FILENAME}"
-        )
+        root_catalog = Catalog.from_file(f"{storage_bucket_path}/{CATALOG_FILENAME}")
 
     else:
         root_catalog = Catalog(
@@ -126,14 +92,11 @@ def handle_root(dataset_prefix: str) -> None:
             description=ROOT_CATALOG_DESCRIPTION,
             catalog_type=CatalogType.SELF_CONTAINED,
         )
-        root_catalog.set_self_href(
-            f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/{CATALOG_FILENAME}"
-        )
+        root_catalog.set_self_href(f"{storage_bucket_path}/{CATALOG_FILENAME}")
 
-    dataset_path = f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/{dataset_prefix}"
-    dataset_catalog = Catalog.from_file(f"{dataset_path}/{CATALOG_FILENAME}")
-
-    root_catalog.add_child(dataset_catalog, strategy=GeostoreSTACLayoutStrategy())
+    dataset_version_metadata = read_file(f"{storage_bucket_path}/{version_metadata_key}")
+    assert isinstance(dataset_version_metadata, (Catalog, Collection))
+    root_catalog.add_child(child=dataset_version_metadata, strategy=GeostoreSTACLayoutStrategy())
     root_catalog.normalize_hrefs(
         f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}",
         strategy=GeostoreSTACLayoutStrategy(),

--- a/geostore/update_dataset_catalog/task.py
+++ b/geostore/update_dataset_catalog/task.py
@@ -7,11 +7,6 @@ import boto3
 from jsonschema import ValidationError, validate
 from linz_logger import get_log
 
-from ..aws_message_attributes import (
-    DATA_TYPE_STRING,
-    MESSAGE_ATTRIBUTE_TYPE_DATASET,
-    MESSAGE_ATTRIBUTE_TYPE_KEY,
-)
 from ..error_response_keys import ERROR_MESSAGE_KEY
 from ..logging_keys import LOG_MESSAGE_LAMBDA_FAILURE, LOG_MESSAGE_LAMBDA_START
 from ..parameter_store import ParameterName, get_param
@@ -72,11 +67,6 @@ def lambda_handler(event: JsonObject, _context: bytes) -> JsonObject:
         QueueName=get_param(ParameterName.UPDATE_CATALOG_MESSAGE_QUEUE_NAME)
     ).send_message(
         MessageBody=new_version_metadata_key,
-        MessageAttributes={
-            MESSAGE_ATTRIBUTE_TYPE_KEY: MessageAttributeValueTypeDef(
-                DataType=DATA_TYPE_STRING, StringValue=MESSAGE_ATTRIBUTE_TYPE_DATASET
-            )
-        },
     )
 
     return {

--- a/geostore/update_dataset_catalog/task.py
+++ b/geostore/update_dataset_catalog/task.py
@@ -24,11 +24,9 @@ from ..types import JsonObject
 if TYPE_CHECKING:
     # When type checking we want to use the third party package's stub
     from mypy_boto3_sqs import SQSServiceResource
-    from mypy_boto3_sqs.type_defs import MessageAttributeValueTypeDef
 else:
     # In production we want to avoid depending on a package which has no runtime impact
     S3Client = SQSServiceResource = object  # pragma: no mutate
-    MessageAttributeValueTypeDef = dict  # pragma: no mutate
 
 LOGGER: Logger = get_log()
 SQS_RESOURCE: SQSServiceResource = boto3.resource("sqs")

--- a/tests/test_populate_catalog.py
+++ b/tests/test_populate_catalog.py
@@ -2,28 +2,17 @@ from copy import deepcopy
 from json import load
 
 import smart_open
-from _pytest.python_api import raises
 from mypy_boto3_s3 import S3Client
 from pytest import mark
 from pytest_subtests import SubTests
 
 from geostore.aws_keys import BODY_KEY
-from geostore.aws_message_attributes import (
-    DATA_TYPE_KEY,
-    DATA_TYPE_STRING,
-    MESSAGE_ATTRIBUTE_TYPE_DATASET,
-    MESSAGE_ATTRIBUTE_TYPE_KEY,
-    MESSAGE_ATTRIBUTE_TYPE_ROOT,
-    STRING_VALUE_KEY_LOWER,
-)
 from geostore.populate_catalog.task import (
     CATALOG_FILENAME,
-    MESSAGE_ATTRIBUTES_KEY,
     RECORDS_KEY,
     ROOT_CATALOG_DESCRIPTION,
     ROOT_CATALOG_ID,
     ROOT_CATALOG_TITLE,
-    UnhandledSQSMessageException,
     lambda_handler,
 )
 from geostore.resources import Resource
@@ -44,7 +33,7 @@ from geostore.stac_format import (
     STAC_TYPE_KEY,
 )
 from geostore.types import JsonList
-from tests.aws_utils import Dataset, S3Object, any_lambda_context, delete_s3_key
+from tests.aws_utils import Dataset, S3Object, any_lambda_context, delete_s3_key, wait_for_s3_key
 from tests.file_utils import json_dict_to_file_object
 from tests.general_generators import any_safe_filename
 from tests.stac_generators import any_dataset_version_id
@@ -57,20 +46,28 @@ from tests.stac_objects import (
 
 @mark.infrastructure
 def should_create_new_root_catalog_if_doesnt_exist(subtests: SubTests, s3_client: S3Client) -> None:
-
+    dataset_version = any_dataset_version_id()
+    catalog_filename = f"{any_safe_filename()}.json"
     with Dataset() as dataset, S3Object(
         file_object=json_dict_to_file_object(
             {
                 **deepcopy(MINIMAL_VALID_STAC_CATALOG_OBJECT),
-                STAC_ID_KEY: dataset.dataset_prefix,
+                STAC_ID_KEY: dataset_version,
                 STAC_TITLE_KEY: dataset.title,
+                STAC_LINKS_KEY: [
+                    {
+                        STAC_REL_KEY: STAC_REL_ROOT,
+                        STAC_HREF_KEY: f"./{catalog_filename}",
+                        STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
+                    },
+                ],
             }
         ),
         bucket_name=Resource.STORAGE_BUCKET_NAME.resource_name,
-        key=f"{dataset.dataset_prefix}/{CATALOG_FILENAME}",
-    ):
+        key=f"{dataset.dataset_prefix}/{dataset_version}/{catalog_filename}",
+    ) as dataset_version_metadata:
 
-        expected_links: JsonList = [
+        expected_root_catalog_links: JsonList = [
             {
                 STAC_REL_KEY: STAC_REL_ROOT,
                 STAC_HREF_KEY: f"./{CATALOG_FILENAME}",
@@ -79,162 +76,54 @@ def should_create_new_root_catalog_if_doesnt_exist(subtests: SubTests, s3_client
             },
             {
                 STAC_REL_KEY: STAC_REL_CHILD,
-                STAC_HREF_KEY: f"./{dataset.dataset_prefix}/{CATALOG_FILENAME}",
+                STAC_HREF_KEY: f"./{dataset.dataset_prefix}/{dataset_version}/{catalog_filename}",
                 STAC_TITLE_KEY: dataset.title,
+                STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
+            },
+        ]
+        expected_dataset_version_links: JsonList = [
+            {
+                STAC_REL_KEY: STAC_REL_ROOT,
+                STAC_HREF_KEY: f"../../{CATALOG_FILENAME}",
+                STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
+                STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
+            },
+            {
+                STAC_REL_KEY: STAC_REL_PARENT,
+                STAC_HREF_KEY: f"../../{CATALOG_FILENAME}",
+                STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
                 STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
             },
         ]
 
         try:
             lambda_handler(
-                {
-                    RECORDS_KEY: [
-                        {
-                            BODY_KEY: dataset.dataset_prefix,
-                            MESSAGE_ATTRIBUTES_KEY: {
-                                MESSAGE_ATTRIBUTE_TYPE_KEY: {
-                                    STRING_VALUE_KEY_LOWER: MESSAGE_ATTRIBUTE_TYPE_ROOT,
-                                    DATA_TYPE_KEY: DATA_TYPE_STRING,
-                                }
-                            },
-                        }
-                    ]
-                },
+                {RECORDS_KEY: [{BODY_KEY: dataset_version_metadata.key}]},
                 any_lambda_context(),
             )
 
-            with smart_open.open(
+            with subtests.test(msg="catalog links"), smart_open.open(
                 f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/{CATALOG_FILENAME}",
                 mode="rb",
             ) as new_root_metadata_file:
                 catalog_json = load(new_root_metadata_file)
+                assert catalog_json[STAC_LINKS_KEY] == expected_root_catalog_links
 
-                with subtests.test(msg="catalog title"):
-                    assert catalog_json[STAC_TITLE_KEY] == ROOT_CATALOG_TITLE
-
-                with subtests.test(msg="catalog description"):
-                    assert catalog_json[STAC_DESCRIPTION_KEY] == ROOT_CATALOG_DESCRIPTION
-
-                with subtests.test(msg="catalog links"):
-                    assert catalog_json[STAC_LINKS_KEY] == expected_links
+            with subtests.test(msg="dataset version links"), smart_open.open(
+                f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}"
+                f"/{dataset_version_metadata.key}",
+                mode="rb",
+            ) as updated_dataset_metadata_file:
+                version_json = load(updated_dataset_metadata_file)
+                assert version_json[STAC_LINKS_KEY] == expected_dataset_version_links
 
         finally:
+            wait_for_s3_key(Resource.STORAGE_BUCKET_NAME.resource_name, CATALOG_FILENAME, s3_client)
             delete_s3_key(Resource.STORAGE_BUCKET_NAME.resource_name, CATALOG_FILENAME, s3_client)
 
 
 @mark.infrastructure
-def should_update_existing_root_catalog(subtests: SubTests) -> None:
-
-    with Dataset() as existing_dataset, S3Object(
-        file_object=json_dict_to_file_object(
-            {
-                **deepcopy(MINIMAL_VALID_STAC_CATALOG_OBJECT),
-                STAC_ID_KEY: existing_dataset.dataset_prefix,
-                STAC_TITLE_KEY: existing_dataset.title,
-            }
-        ),
-        bucket_name=Resource.STORAGE_BUCKET_NAME.resource_name,
-        key=f"{existing_dataset.dataset_prefix}/{CATALOG_FILENAME}",
-    ):
-
-        original_links: JsonList = [
-            {
-                STAC_REL_KEY: STAC_REL_ROOT,
-                STAC_HREF_KEY: f"./{CATALOG_FILENAME}",
-                STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
-                STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-            },
-            {
-                STAC_REL_KEY: STAC_REL_CHILD,
-                STAC_HREF_KEY: f"./{existing_dataset.dataset_prefix}/{CATALOG_FILENAME}",
-                STAC_TITLE_KEY: existing_dataset.title,
-                STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-            },
-        ]
-
-        with Dataset() as dataset, S3Object(
-            file_object=json_dict_to_file_object(
-                {
-                    **deepcopy(MINIMAL_VALID_STAC_CATALOG_OBJECT),
-                    STAC_ID_KEY: dataset.dataset_prefix,
-                    STAC_TITLE_KEY: dataset.title,
-                }
-            ),
-            bucket_name=Resource.STORAGE_BUCKET_NAME.resource_name,
-            key=f"{dataset.dataset_prefix}/{CATALOG_FILENAME}",
-        ), S3Object(
-            file_object=json_dict_to_file_object(
-                {
-                    **deepcopy(MINIMAL_VALID_STAC_CATALOG_OBJECT),
-                    STAC_ID_KEY: ROOT_CATALOG_ID,
-                    STAC_DESCRIPTION_KEY: ROOT_CATALOG_DESCRIPTION,
-                    STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
-                    STAC_LINKS_KEY: original_links,
-                }
-            ),
-            bucket_name=Resource.STORAGE_BUCKET_NAME.resource_name,
-            key=CATALOG_FILENAME,
-        ):
-
-            expected_root_links: JsonList = original_links + [
-                {
-                    STAC_REL_KEY: STAC_REL_CHILD,
-                    STAC_HREF_KEY: f"./{dataset.dataset_prefix}/{CATALOG_FILENAME}",
-                    STAC_TITLE_KEY: dataset.title,
-                    STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-                }
-            ]
-
-            expected_dataset_links: JsonList = [
-                {
-                    STAC_REL_KEY: STAC_REL_ROOT,
-                    STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
-                    STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
-                    STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-                },
-                {
-                    STAC_REL_KEY: STAC_REL_PARENT,
-                    STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
-                    STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
-                    STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-                },
-            ]
-
-            lambda_handler(
-                {
-                    RECORDS_KEY: [
-                        {
-                            BODY_KEY: dataset.dataset_prefix,
-                            MESSAGE_ATTRIBUTES_KEY: {
-                                MESSAGE_ATTRIBUTE_TYPE_KEY: {
-                                    STRING_VALUE_KEY_LOWER: MESSAGE_ATTRIBUTE_TYPE_ROOT,
-                                    DATA_TYPE_KEY: DATA_TYPE_STRING,
-                                }
-                            },
-                        }
-                    ]
-                },
-                any_lambda_context(),
-            )
-
-            with smart_open.open(
-                f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/{CATALOG_FILENAME}",
-                mode="rb",
-            ) as root_metadata_file, subtests.test(msg="root catalog links"):
-                root_catalog_json = load(root_metadata_file)
-                assert root_catalog_json[STAC_LINKS_KEY] == expected_root_links
-
-            with smart_open.open(
-                f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}"
-                f"/{dataset.dataset_prefix}/{CATALOG_FILENAME}",
-                mode="rb",
-            ) as dataset_metadata_file, subtests.test(msg="dataset catalog links"):
-                dataset_catalog_json = load(dataset_metadata_file)
-                assert dataset_catalog_json[STAC_LINKS_KEY] == expected_dataset_links
-
-
-@mark.infrastructure
-def should_update_dataset_catalog_with_new_version_catalog(subtests: SubTests) -> None:
+def should_update_root_catalog_with_new_version_catalog(subtests: SubTests) -> None:
     collection_filename = f"{any_safe_filename()}.json"
     item_filename = f"{any_safe_filename()}.json"
     dataset_version = any_dataset_version_id()
@@ -313,28 +202,6 @@ def should_update_dataset_catalog_with_new_version_catalog(subtests: SubTests) -
         file_object=json_dict_to_file_object(
             {
                 **deepcopy(MINIMAL_VALID_STAC_CATALOG_OBJECT),
-                STAC_ID_KEY: dataset.dataset_prefix,
-                STAC_TITLE_KEY: dataset.title,
-                STAC_LINKS_KEY: [
-                    {
-                        STAC_REL_KEY: STAC_REL_ROOT,
-                        STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
-                        STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-                    },
-                    {
-                        STAC_REL_KEY: STAC_REL_PARENT,
-                        STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
-                        STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-                    },
-                ],
-            }
-        ),
-        bucket_name=Resource.STORAGE_BUCKET_NAME.resource_name,
-        key=f"{dataset.dataset_prefix}/{CATALOG_FILENAME}",
-    ), S3Object(
-        file_object=json_dict_to_file_object(
-            {
-                **deepcopy(MINIMAL_VALID_STAC_CATALOG_OBJECT),
                 STAC_ID_KEY: ROOT_CATALOG_ID,
                 STAC_DESCRIPTION_KEY: ROOT_CATALOG_DESCRIPTION,
                 STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
@@ -344,11 +211,6 @@ def should_update_dataset_catalog_with_new_version_catalog(subtests: SubTests) -
                         STAC_HREF_KEY: f"./{CATALOG_FILENAME}",
                         STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
                     },
-                    {
-                        STAC_REL_KEY: STAC_REL_CHILD,
-                        STAC_HREF_KEY: f"./{dataset.dataset_prefix}/{CATALOG_FILENAME}",
-                        STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-                    },
                 ],
             }
         ),
@@ -356,22 +218,16 @@ def should_update_dataset_catalog_with_new_version_catalog(subtests: SubTests) -
         key=CATALOG_FILENAME,
     ):
 
-        expected_dataset_catalog_links: JsonList = [
+        expected_root_catalog_links: JsonList = [
             {
                 STAC_REL_KEY: STAC_REL_ROOT,
-                STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
-                STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
-                STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-            },
-            {
-                STAC_REL_KEY: STAC_REL_PARENT,
-                STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
+                STAC_HREF_KEY: f"./{CATALOG_FILENAME}",
                 STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
                 STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
             },
             {
                 STAC_REL_KEY: STAC_REL_CHILD,
-                STAC_HREF_KEY: f"./{dataset_version}/{catalog_filename}",
+                STAC_HREF_KEY: f"./{dataset.dataset_prefix}/{dataset_version}/{catalog_filename}",
                 STAC_TITLE_KEY: dataset.title,
                 STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
             },
@@ -391,36 +247,23 @@ def should_update_dataset_catalog_with_new_version_catalog(subtests: SubTests) -
             },
             {
                 STAC_REL_KEY: STAC_REL_PARENT,
-                STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
-                STAC_TITLE_KEY: dataset.title,
+                STAC_HREF_KEY: f"../../{CATALOG_FILENAME}",
+                STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
                 STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
             },
         ]
 
         lambda_handler(
-            {
-                RECORDS_KEY: [
-                    {
-                        BODY_KEY: dataset_version_metadata.key,
-                        MESSAGE_ATTRIBUTES_KEY: {
-                            MESSAGE_ATTRIBUTE_TYPE_KEY: {
-                                STRING_VALUE_KEY_LOWER: MESSAGE_ATTRIBUTE_TYPE_DATASET,
-                                DATA_TYPE_KEY: DATA_TYPE_STRING,
-                            }
-                        },
-                    }
-                ]
-            },
+            {RECORDS_KEY: [{BODY_KEY: dataset_version_metadata.key}]},
             any_lambda_context(),
         )
 
-        with subtests.test(msg="dataset catalog links"), smart_open.open(
-            f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/"
-            f"{dataset.dataset_prefix}/{CATALOG_FILENAME}",
+        with subtests.test(msg="root catalog links"), smart_open.open(
+            f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/{CATALOG_FILENAME}",
             mode="rb",
-        ) as updated_dataset_metadata_file:
-            catalog_json = load(updated_dataset_metadata_file)
-            assert catalog_json[STAC_LINKS_KEY] == expected_dataset_catalog_links
+        ) as updated_root_metadata_file:
+            catalog_json = load(updated_root_metadata_file)
+            assert catalog_json[STAC_LINKS_KEY] == expected_root_catalog_links
 
         with subtests.test(msg="dataset version links"), smart_open.open(
             f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}"
@@ -432,7 +275,8 @@ def should_update_dataset_catalog_with_new_version_catalog(subtests: SubTests) -
 
 
 @mark.infrastructure
-def should_update_dataset_catalog_with_new_version_collection(subtests: SubTests) -> None:
+def should_update_root_catalog_with_new_version_collection(subtests: SubTests) -> None:
+    # pylint: disable=too-many-locals
     dataset_version = any_dataset_version_id()
     collection_filename = f"{any_safe_filename()}.json"
     item_filename = f"{any_safe_filename()}.json"
@@ -484,28 +328,6 @@ def should_update_dataset_catalog_with_new_version_collection(subtests: SubTests
         file_object=json_dict_to_file_object(
             {
                 **deepcopy(MINIMAL_VALID_STAC_CATALOG_OBJECT),
-                STAC_ID_KEY: dataset.dataset_prefix,
-                STAC_TITLE_KEY: dataset.title,
-                STAC_LINKS_KEY: [
-                    {
-                        STAC_REL_KEY: STAC_REL_ROOT,
-                        STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
-                        STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-                    },
-                    {
-                        STAC_REL_KEY: STAC_REL_PARENT,
-                        STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
-                        STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-                    },
-                ],
-            }
-        ),
-        bucket_name=Resource.STORAGE_BUCKET_NAME.resource_name,
-        key=f"{dataset.dataset_prefix}/{CATALOG_FILENAME}",
-    ), S3Object(
-        file_object=json_dict_to_file_object(
-            {
-                **deepcopy(MINIMAL_VALID_STAC_CATALOG_OBJECT),
                 STAC_ID_KEY: ROOT_CATALOG_ID,
                 STAC_DESCRIPTION_KEY: ROOT_CATALOG_DESCRIPTION,
                 STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
@@ -514,34 +336,24 @@ def should_update_dataset_catalog_with_new_version_collection(subtests: SubTests
                         STAC_REL_KEY: STAC_REL_ROOT,
                         STAC_HREF_KEY: f"./{CATALOG_FILENAME}",
                         STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-                    },
-                    {
-                        STAC_REL_KEY: STAC_REL_CHILD,
-                        STAC_HREF_KEY: f"./{dataset.dataset_prefix}/{CATALOG_FILENAME}",
-                        STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-                    },
+                    }
                 ],
             }
         ),
         bucket_name=Resource.STORAGE_BUCKET_NAME.resource_name,
         key=CATALOG_FILENAME,
     ):
-        expected_dataset_catalog_links: JsonList = [
+        expected_root_catalog_links: JsonList = [
             {
                 STAC_REL_KEY: STAC_REL_ROOT,
-                STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
-                STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
-                STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
-            },
-            {
-                STAC_REL_KEY: STAC_REL_PARENT,
-                STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
+                STAC_HREF_KEY: f"./{CATALOG_FILENAME}",
                 STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
                 STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
             },
             {
                 STAC_REL_KEY: STAC_REL_CHILD,
-                STAC_HREF_KEY: f"./{dataset_version}/{collection_filename}",
+                STAC_HREF_KEY: f"./{dataset.dataset_prefix}/{dataset_version}/"
+                f"{collection_filename}",
                 STAC_TITLE_KEY: dataset.title,
                 STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
             },
@@ -560,8 +372,8 @@ def should_update_dataset_catalog_with_new_version_collection(subtests: SubTests
             },
             {
                 STAC_REL_KEY: STAC_REL_PARENT,
-                STAC_HREF_KEY: f"../{CATALOG_FILENAME}",
-                STAC_TITLE_KEY: dataset.title,
+                STAC_HREF_KEY: f"../../{CATALOG_FILENAME}",
+                STAC_TITLE_KEY: ROOT_CATALOG_TITLE,
                 STAC_TYPE_KEY: STAC_MEDIA_TYPE_JSON,
             },
         ]
@@ -581,29 +393,16 @@ def should_update_dataset_catalog_with_new_version_collection(subtests: SubTests
         ]
 
         lambda_handler(
-            {
-                RECORDS_KEY: [
-                    {
-                        BODY_KEY: dataset_version_metadata.key,
-                        MESSAGE_ATTRIBUTES_KEY: {
-                            MESSAGE_ATTRIBUTE_TYPE_KEY: {
-                                STRING_VALUE_KEY_LOWER: MESSAGE_ATTRIBUTE_TYPE_DATASET,
-                                DATA_TYPE_KEY: DATA_TYPE_STRING,
-                            }
-                        },
-                    }
-                ]
-            },
+            {RECORDS_KEY: [{BODY_KEY: dataset_version_metadata.key}]},
             any_lambda_context(),
         )
 
-        with subtests.test(msg="dataset catalog links"), smart_open.open(
-            f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/"
-            f"{dataset.dataset_prefix}/{CATALOG_FILENAME}",
+        with subtests.test(msg="root catalog links"), smart_open.open(
+            f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/{CATALOG_FILENAME}",
             mode="rb",
-        ) as updated_dataset_metadata_file:
-            catalog_json = load(updated_dataset_metadata_file)
-            assert catalog_json[STAC_LINKS_KEY] == expected_dataset_catalog_links
+        ) as updated_root_metadata_file:
+            catalog_json = load(updated_root_metadata_file)
+            assert catalog_json[STAC_LINKS_KEY] == expected_root_catalog_links
 
         with subtests.test(msg="dataset version links"), smart_open.open(
             f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}"
@@ -619,23 +418,3 @@ def should_update_dataset_catalog_with_new_version_collection(subtests: SubTests
         ) as updated_item_metadata_file:
             item_json = load(updated_item_metadata_file)
             assert item_json[STAC_LINKS_KEY] == expected_item_links
-
-
-def should_fail_if_unknown_sqs_message_type() -> None:
-    with raises(UnhandledSQSMessageException):
-        lambda_handler(
-            {
-                RECORDS_KEY: [
-                    {
-                        BODY_KEY: any_dataset_version_id(),
-                        MESSAGE_ATTRIBUTES_KEY: {
-                            MESSAGE_ATTRIBUTE_TYPE_KEY: {
-                                STRING_VALUE_KEY_LOWER: "test",
-                                DATA_TYPE_KEY: DATA_TYPE_STRING,
-                            }
-                        },
-                    }
-                ]
-            },
-            any_lambda_context(),
-        )

--- a/tests/test_processing_stack.py
+++ b/tests/test_processing_stack.py
@@ -260,17 +260,14 @@ def should_successfully_run_dataset_version_creation_process_with_multiple_asset
             )
             dataset_payload = load(dataset_response["Payload"])
 
-            assert dataset_payload.get(STATUS_CODE_KEY) == HTTPStatus.CREATED, dataset_payload
-
             dataset_id = dataset_payload[BODY_KEY][DATASET_ID_SHORT_KEY]
             dataset_prefix = f"{dataset_title}{DATASET_KEY_SEPARATOR}{dataset_id}"
 
-            with subtests.test(msg="Dataset catalog is created"):
-                wait_for_s3_key(
-                    Resource.STORAGE_BUCKET_NAME.resource_name,
-                    f"{dataset_prefix}/{CATALOG_FILENAME}",
-                    s3_client,
-                )
+            wait_for_s3_key(
+                Resource.STORAGE_BUCKET_NAME.resource_name,
+                f"{dataset_prefix}/{CATALOG_FILENAME}",
+                s3_client,
+            )
 
             dataset_versions_response = lambda_client.invoke(
                 FunctionName=Resource.DATASET_VERSIONS_ENDPOINT_FUNCTION_NAME.resource_name,
@@ -594,18 +591,14 @@ def should_successfully_run_dataset_version_creation_process_with_single_asset(
                 ).encode(),
             )
             dataset_payload = load(dataset_response["Payload"])
-
-            assert dataset_payload.get(STATUS_CODE_KEY) == HTTPStatus.CREATED, dataset_payload
-
             dataset_id = dataset_payload[BODY_KEY][DATASET_ID_SHORT_KEY]
             dataset_prefix = f"{dataset_title}{DATASET_KEY_SEPARATOR}{dataset_id}"
 
-            with subtests.test(msg="Dataset catalog is created"):
-                wait_for_s3_key(
-                    Resource.STORAGE_BUCKET_NAME.resource_name,
-                    f"{dataset_prefix}/{CATALOG_FILENAME}",
-                    s3_client,
-                )
+            wait_for_s3_key(
+                Resource.STORAGE_BUCKET_NAME.resource_name,
+                f"{dataset_prefix}/{CATALOG_FILENAME}",
+                s3_client,
+            )
 
             dataset_versions_response = lambda_client.invoke(
                 FunctionName=Resource.DATASET_VERSIONS_ENDPOINT_FUNCTION_NAME.resource_name,
@@ -756,9 +749,6 @@ def should_not_copy_files_when_there_is_a_checksum_mismatch(
                 ).encode(),
             )
             dataset_payload = load(dataset_response["Payload"])
-
-            assert dataset_payload.get(STATUS_CODE_KEY) == HTTPStatus.CREATED, dataset_payload
-
             dataset_id = dataset_payload[BODY_KEY][DATASET_ID_SHORT_KEY]
             dataset_prefix = f"{dataset_title}{DATASET_KEY_SEPARATOR}{dataset_id}"
 

--- a/tests/test_processing_stack.py
+++ b/tests/test_processing_stack.py
@@ -315,8 +315,8 @@ def should_successfully_run_dataset_version_creation_process_with_multiple_asset
             storage_bucket_prefix = f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/"
 
             with subtests.test(msg="Should update dataset catalog successfully"):
-                # Then poll dataset catalog for expected link to child catalog
-                expected_child_link_object = {
+                # Then poll dataset catalog
+                dataset_version_link = {
                     STAC_HREF_KEY: f"./{dataset_versions_body[VERSION_ID_KEY]}"
                     f"/{catalog_metadata_filename}",
                     STAC_REL_KEY: STAC_REL_CHILD,
@@ -325,14 +325,9 @@ def should_successfully_run_dataset_version_creation_process_with_multiple_asset
                 process_timeout = datetime.now() + timedelta(minutes=1)
 
                 while (
-                    expected_child_link_object
+                    dataset_version_link
                     not in (
-                        load(
-                            smart_open.open(
-                                f"{storage_bucket_prefix}{dataset_prefix}" f"/{CATALOG_FILENAME}",
-                                mode="rb",
-                            )
-                        )
+                        load(smart_open.open(f"{dataset_prefix}/{CATALOG_FILENAME}", mode="rb"))
                     )[STAC_LINKS_KEY]
                 ):
                     assert datetime.now() < process_timeout  # pragma: no cover

--- a/tests/test_processing_stack.py
+++ b/tests/test_processing_stack.py
@@ -314,7 +314,7 @@ def should_successfully_run_dataset_version_creation_process_with_multiple_asset
             storage_bucket_prefix = f"{S3_URL_PREFIX}{Resource.STORAGE_BUCKET_NAME.resource_name}/"
 
             with subtests.test(msg="Should update dataset catalog successfully"):
-                # Then poll dataset catalog
+                # Then poll dataset catalog for expected link to child catalog
                 expected_child_link_object = {
                     STAC_HREF_KEY: f"./{dataset_versions_body[VERSION_ID_KEY]}"
                     f"/{catalog_metadata_filename}",

--- a/tests/test_update_dataset_catalog.py
+++ b/tests/test_update_dataset_catalog.py
@@ -5,13 +5,6 @@ from jsonschema import ValidationError
 from pytest import mark
 from pytest_subtests import SubTests
 
-from geostore.aws_message_attributes import (
-    DATA_TYPE_KEY,
-    DATA_TYPE_STRING,
-    MESSAGE_ATTRIBUTE_TYPE_DATASET,
-    MESSAGE_ATTRIBUTE_TYPE_KEY,
-    STRING_VALUE_KEY,
-)
 from geostore.error_response_keys import ERROR_MESSAGE_KEY
 from geostore.resources import Resource
 from geostore.s3 import S3_URL_PREFIX
@@ -58,15 +51,7 @@ def should_succeed_and_trigger_sqs_update_to_catalog(subtests: SubTests) -> None
             any_lambda_context(),
         )
 
-        expected_sqs_call = {
-            "MessageBody": dataset_version_metadata.key,
-            "MessageAttributes": {
-                MESSAGE_ATTRIBUTE_TYPE_KEY: {
-                    STRING_VALUE_KEY: MESSAGE_ATTRIBUTE_TYPE_DATASET,
-                    DATA_TYPE_KEY: DATA_TYPE_STRING,
-                }
-            },
-        }
+        expected_sqs_call = {"MessageBody": dataset_version_metadata.key}
 
         with subtests.test(msg="success"):
             assert response == {


### PR DESCRIPTION
Instead, new versions will be referenced directly in the root catalog. This is an intermediary step to allowing Datasets to be updated in place rather than having to create a new dataset version.
