### PR TITLE
chore: Upgrade AWS CDK to version 2

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
 """
 CDK application entry point file.
 """
-from aws_cdk.core import App, Tag
+from aws_cdk import App, Tags
 
 from geostore.environment import environment_name
 from infrastructure.application_stack import Application
@@ -15,12 +15,12 @@ def main() -> None:
     Application(app, f"{env_name}-geostore")
 
     # tag all resources in stack
-    Tag.add(app, "CostCentre", "100005")
-    Tag.add(app, APPLICATION_NAME_TAG_NAME, APPLICATION_NAME)
-    Tag.add(app, "Owner", "Bill M. Nelson")
-    Tag.add(app, "EnvironmentType", env_name)
-    Tag.add(app, "SupportType", "Dev")
-    Tag.add(app, "HoursOfOperation", "24x7")
+    Tags.of(app).add("CostCentre", "100005")
+    Tags.of(app).add(APPLICATION_NAME_TAG_NAME, APPLICATION_NAME)
+    Tags.of(app).add("Owner", "Bill M. Nelson")
+    Tags.of(app).add("EnvironmentType", env_name)
+    Tags.of(app).add("SupportType", "Dev")
+    Tags.of(app).add("HoursOfOperation", "24x7")
 
     app.synth()
 

--- a/cdk.json
+++ b/cdk.json
@@ -1,7 +1,6 @@
 {
   "app": "python3 app.py",
   "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": true,
     "@aws-cdk/core:newStyleStackSynthesis": true,
     "@aws-cdk/core:stackRelativeExports": true,
     "@aws-cdk:enableDiffNoFail": true,

--- a/infrastructure/application_stack.py
+++ b/infrastructure/application_stack.py
@@ -1,8 +1,7 @@
 from os import environ
 
 import constructs
-from aws_cdk import aws_iam
-from aws_cdk.core import Environment, Stack
+from aws_cdk import Environment, Stack, aws_iam
 
 from geostore.environment import environment_name
 

--- a/infrastructure/constructs/api.py
+++ b/infrastructure/constructs/api.py
@@ -1,5 +1,13 @@
-from aws_cdk import aws_iam, aws_lambda_python, aws_s3, aws_sqs, aws_ssm, aws_stepfunctions
-from aws_cdk.core import Construct, Tags
+from aws_cdk import (
+    Tags,
+    aws_iam,
+    aws_lambda_python_alpha,
+    aws_s3,
+    aws_sqs,
+    aws_ssm,
+    aws_stepfunctions,
+)
+from constructs import Construct
 
 from geostore.resources import Resource
 
@@ -18,7 +26,7 @@ class API(Construct):
         scope: Construct,
         stack_id: str,
         *,
-        botocore_lambda_layer: aws_lambda_python.PythonLayerVersion,
+        botocore_lambda_layer: aws_lambda_python_alpha.PythonLayerVersion,
         datasets_table: Table,
         env_name: str,
         state_machine: aws_stepfunctions.StateMachine,

--- a/infrastructure/constructs/batch_job_queue.py
+++ b/infrastructure/constructs/batch_job_queue.py
@@ -1,7 +1,7 @@
 import textwrap
 
-from aws_cdk import aws_batch, aws_dynamodb, aws_ec2, aws_iam
-from aws_cdk.core import Construct, Fn
+from aws_cdk import Fn, aws_batch_alpha, aws_dynamodb, aws_ec2, aws_iam
+from constructs import Construct
 
 from geostore.environment import is_production
 
@@ -76,7 +76,7 @@ class BatchJobQueue(Construct):
             launch_template_data=launch_template_data,
         )
         assert cloudformation_launch_template.launch_template_name is not None
-        launch_template = aws_batch.LaunchTemplateSpecification(
+        launch_template = aws_batch_alpha.LaunchTemplateSpecification(
             launch_template_name=cloudformation_launch_template.launch_template_name
         )
 
@@ -92,14 +92,14 @@ class BatchJobQueue(Construct):
             },
         )
 
-        compute_resources = aws_batch.ComputeResources(
+        compute_resources = aws_batch_alpha.ComputeResources(
             vpc=vpc,
             minv_cpus=0,
             desiredv_cpus=0,
             maxv_cpus=1000,
             instance_types=instance_types,
             instance_role=batch_instance_profile.instance_profile_name,
-            allocation_strategy=aws_batch.AllocationStrategy("BEST_FIT_PROGRESSIVE"),
+            allocation_strategy=aws_batch_alpha.AllocationStrategy("BEST_FIT_PROGRESSIVE"),
             launch_template=launch_template,
         )
         batch_service_policy = aws_iam.ManagedPolicy.from_aws_managed_policy_name(
@@ -111,18 +111,18 @@ class BatchJobQueue(Construct):
             assumed_by=aws_iam.ServicePrincipal("batch.amazonaws.com"),
             managed_policies=[batch_service_policy],
         )
-        compute_environment = aws_batch.ComputeEnvironment(
+        compute_environment = aws_batch_alpha.ComputeEnvironment(
             self,
             "compute-environment",
             compute_resources=compute_resources,
             service_role=service_role,
         )
 
-        self.job_queue = aws_batch.JobQueue(
+        self.job_queue = aws_batch_alpha.JobQueue(
             scope,
             f"{construct_id}-job-queue",
             compute_environments=[
-                aws_batch.JobQueueComputeEnvironment(
+                aws_batch_alpha.JobQueueComputeEnvironment(
                     compute_environment=compute_environment, order=10
                 ),
             ],

--- a/infrastructure/constructs/batch_submit_job_task.py
+++ b/infrastructure/constructs/batch_submit_job_task.py
@@ -1,7 +1,7 @@
 from typing import List, Mapping, Optional
 
-from aws_cdk import aws_batch, aws_iam, aws_stepfunctions, aws_stepfunctions_tasks
-from aws_cdk.core import Construct
+from aws_cdk import aws_batch_alpha, aws_iam, aws_stepfunctions, aws_stepfunctions_tasks
+from constructs import Construct
 
 from .common import LOG_LEVEL
 from .task_job_definition import TaskJobDefinition
@@ -16,7 +16,7 @@ class BatchSubmitJobTask(Construct):
         env_name: str,
         directory: str,
         s3_policy: aws_iam.IManagedPolicy,
-        job_queue: aws_batch.JobQueue,
+        job_queue: aws_batch_alpha.JobQueue,
         payload_object: Mapping[str, str],
         container_overrides_command: List[str],
         array_size: Optional[int] = None,

--- a/infrastructure/constructs/bundled_code.py
+++ b/infrastructure/constructs/bundled_code.py
@@ -1,7 +1,6 @@
 from os.path import join
 
-from aws_cdk import aws_lambda
-from aws_cdk.core import BundlingOptions
+from aws_cdk import BundlingOptions, aws_lambda
 
 from .backend import BACKEND_DIRECTORY
 from .lambda_config import PYTHON_RUNTIME
@@ -9,7 +8,7 @@ from .lambda_config import PYTHON_RUNTIME
 
 def bundled_code(directory: str) -> aws_lambda.Code:
     bundling_options = BundlingOptions(
-        image=PYTHON_RUNTIME.bundling_docker_image,  # pylint:disable=no-member
+        image=PYTHON_RUNTIME.bundling_image,  # pylint:disable=no-member
         command=[join(BACKEND_DIRECTORY, "bundle.bash"), directory],
     )
     return aws_lambda.Code.from_asset(path=".", bundling=bundling_options)

--- a/infrastructure/constructs/bundled_lambda_function.py
+++ b/infrastructure/constructs/bundled_lambda_function.py
@@ -1,7 +1,7 @@
 from typing import Mapping, Optional
 
-from aws_cdk import aws_lambda, aws_lambda_python
-from aws_cdk.core import Construct, Duration
+from aws_cdk import Duration, aws_lambda, aws_lambda_python_alpha
+from constructs import Construct
 
 from .backend import BACKEND_DIRECTORY
 from .bundled_code import bundled_code
@@ -21,7 +21,7 @@ class BundledLambdaFunction(aws_lambda.Function):
         *,
         directory: str,
         extra_environment: Optional[Mapping[str, str]],
-        botocore_lambda_layer: aws_lambda_python.PythonLayerVersion,
+        botocore_lambda_layer: aws_lambda_python_alpha.PythonLayerVersion,
         timeout: Duration = DEFAULT_LAMBDA_TIMEOUT,
     ):
         environment = {"LOGLEVEL": LOG_LEVEL}

--- a/infrastructure/constructs/import_file_function.py
+++ b/infrastructure/constructs/import_file_function.py
@@ -1,5 +1,5 @@
-from aws_cdk import aws_iam, aws_lambda_python
-from aws_cdk.core import Construct, Duration
+from aws_cdk import Duration, aws_iam, aws_lambda_python_alpha
+from constructs import Construct
 
 from geostore.environment import ENV_NAME_VARIABLE_NAME
 
@@ -16,7 +16,7 @@ class ImportFileFunction(BundledLambdaFunction):
         directory: str,
         invoker: aws_iam.Role,
         env_name: str,
-        botocore_lambda_layer: aws_lambda_python.PythonLayerVersion,
+        botocore_lambda_layer: aws_lambda_python_alpha.PythonLayerVersion,
         timeout: Duration = DEFAULT_LAMBDA_TIMEOUT,
     ):
         super().__init__(

--- a/infrastructure/constructs/lambda_config.py
+++ b/infrastructure/constructs/lambda_config.py
@@ -1,5 +1,4 @@
-from aws_cdk import aws_lambda
-from aws_cdk.core import Duration
+from aws_cdk import Duration, aws_lambda
 
 PYTHON_RUNTIME = aws_lambda.Runtime.PYTHON_3_8
 

--- a/infrastructure/constructs/lambda_endpoint.py
+++ b/infrastructure/constructs/lambda_endpoint.py
@@ -1,5 +1,5 @@
-from aws_cdk import aws_iam, aws_lambda, aws_lambda_python
-from aws_cdk.core import Construct
+from aws_cdk import aws_iam, aws_lambda, aws_lambda_python_alpha
+from constructs import Construct
 
 from geostore.environment import ENV_NAME_VARIABLE_NAME
 
@@ -21,7 +21,7 @@ class LambdaEndpoint(aws_lambda.Function):
         env_name: str,
         users_role: aws_iam.Role,
         package_name: str,
-        botocore_lambda_layer: aws_lambda_python.PythonLayerVersion,
+        botocore_lambda_layer: aws_lambda_python_alpha.PythonLayerVersion,
     ):
         super().__init__(
             scope,

--- a/infrastructure/constructs/lambda_layers.py
+++ b/infrastructure/constructs/lambda_layers.py
@@ -1,6 +1,6 @@
 import constructs
-from aws_cdk import aws_lambda_python
-from aws_cdk.core import Construct
+from aws_cdk import aws_lambda_python_alpha
+from constructs import Construct
 
 from .lambda_config import PYTHON_RUNTIME
 
@@ -9,7 +9,7 @@ class LambdaLayers(Construct):
     def __init__(self, scope: constructs.Construct, stack_id: str, *, env_name: str) -> None:
         super().__init__(scope, stack_id)
 
-        self.botocore = aws_lambda_python.PythonLayerVersion(
+        self.botocore = aws_lambda_python_alpha.PythonLayerVersion(
             self,
             f"{env_name}-botocore-lambda-layer",
             entry="infrastructure/constructs/lambda_layers/botocore",

--- a/infrastructure/constructs/lambda_task.py
+++ b/infrastructure/constructs/lambda_task.py
@@ -1,8 +1,8 @@
 from typing import Mapping, Optional
 
-from aws_cdk import aws_lambda_python, aws_stepfunctions_tasks
+from aws_cdk import aws_lambda_python_alpha, aws_stepfunctions_tasks
 from aws_cdk.aws_stepfunctions import JsonPath
-from aws_cdk.core import Construct
+from constructs import Construct
 
 from .bundled_lambda_function import BundledLambdaFunction
 
@@ -14,7 +14,7 @@ class LambdaTask(aws_stepfunctions_tasks.LambdaInvoke):
         construct_id: str,
         *,
         directory: str,
-        botocore_lambda_layer: aws_lambda_python.PythonLayerVersion,
+        botocore_lambda_layer: aws_lambda_python_alpha.PythonLayerVersion,
         result_path: Optional[str] = JsonPath.DISCARD,
         extra_environment: Optional[Mapping[str, str]] = None,
     ):

--- a/infrastructure/constructs/lds.py
+++ b/infrastructure/constructs/lds.py
@@ -1,5 +1,5 @@
-from aws_cdk import aws_iam, aws_s3
-from aws_cdk.core import Construct, Tags
+from aws_cdk import Tags, aws_iam, aws_s3
+from constructs import Construct
 
 from geostore.environment import is_production
 
@@ -22,7 +22,7 @@ class LDS(Construct):
             "koordinates-read-role",
             role_name=f"koordinates-s3-access-read-{env_name}",
             assumed_by=account_principal,
-            external_id=external_id,
+            external_ids=[external_id],
             max_session_duration=MAX_SESSION_DURATION,
         )
         storage_bucket.grant_read(role)

--- a/infrastructure/constructs/notify.py
+++ b/infrastructure/constructs/notify.py
@@ -4,12 +4,12 @@ from aws_cdk import (
     aws_events,
     aws_events_targets,
     aws_iam,
-    aws_lambda_python,
+    aws_lambda_python_alpha,
     aws_sns,
     aws_ssm,
     aws_stepfunctions,
 )
-from aws_cdk.core import Construct
+from constructs import Construct
 
 from geostore.environment import ENV_NAME_VARIABLE_NAME
 from geostore.notify_status_update.task import SLACK_URL_ENV_NAME
@@ -28,7 +28,7 @@ class Notify(Construct):
         scope: Construct,
         stack_id: str,
         *,
-        botocore_lambda_layer: aws_lambda_python.PythonLayerVersion,
+        botocore_lambda_layer: aws_lambda_python_alpha.PythonLayerVersion,
         env_name: str,
         state_machine: aws_stepfunctions.StateMachine,
         validation_results_table: Table,

--- a/infrastructure/constructs/opentopo.py
+++ b/infrastructure/constructs/opentopo.py
@@ -1,5 +1,5 @@
-from aws_cdk import aws_iam, aws_s3
-from aws_cdk.core import Construct, Tags
+from aws_cdk import Tags, aws_iam, aws_s3
+from constructs import Construct
 
 from .roles import MAX_SESSION_DURATION
 
@@ -17,7 +17,7 @@ class OpenTopography(Construct):
             "opentopography-read-role",
             role_name=f"opentopography-s3-access-read-{env_name}",
             assumed_by=account_principal,
-            external_id=external_id,
+            external_ids=[external_id],
             max_session_duration=MAX_SESSION_DURATION,
         )
         storage_bucket.grant_read(role)

--- a/infrastructure/constructs/processing.py
+++ b/infrastructure/constructs/processing.py
@@ -1,7 +1,9 @@
 from aws_cdk import (
+    Duration,
+    Tags,
     aws_dynamodb,
     aws_iam,
-    aws_lambda_python,
+    aws_lambda_python_alpha,
     aws_s3,
     aws_sqs,
     aws_ssm,
@@ -9,7 +11,7 @@ from aws_cdk import (
 )
 from aws_cdk.aws_lambda_event_sources import SqsEventSource
 from aws_cdk.aws_stepfunctions import Wait, WaitTime
-from aws_cdk.core import Construct, Duration, Tags
+from constructs import Construct
 
 from geostore.api_keys import SUCCESS_KEY
 from geostore.content_iterator.task import (
@@ -58,7 +60,7 @@ class Processing(Construct):
         scope: Construct,
         stack_id: str,
         *,
-        botocore_lambda_layer: aws_lambda_python.PythonLayerVersion,
+        botocore_lambda_layer: aws_lambda_python_alpha.PythonLayerVersion,
         env_name: str,
         principal: aws_iam.PrincipalBase,
         storage_bucket: aws_s3.Bucket,

--- a/infrastructure/constructs/removal_policy.py
+++ b/infrastructure/constructs/removal_policy.py
@@ -1,6 +1,6 @@
 from os import environ
 
-from aws_cdk.core import RemovalPolicy
+from aws_cdk import RemovalPolicy
 
 if environ.get("RESOURCE_REMOVAL_POLICY", "DESTROY").upper() == "RETAIN":
     REMOVAL_POLICY = RemovalPolicy.RETAIN

--- a/infrastructure/constructs/roles.py
+++ b/infrastructure/constructs/roles.py
@@ -1,3 +1,3 @@
-from aws_cdk.core import Duration
+from aws_cdk import Duration
 
 MAX_SESSION_DURATION = Duration.hours(12)

--- a/infrastructure/constructs/staging.py
+++ b/infrastructure/constructs/staging.py
@@ -1,5 +1,5 @@
-from aws_cdk import aws_iam, aws_s3
-from aws_cdk.core import Construct, RemovalPolicy, Tags
+from aws_cdk import RemovalPolicy, Tags, aws_iam, aws_s3
+from constructs import Construct
 
 from geostore.resources import Resource
 

--- a/infrastructure/constructs/storage.py
+++ b/infrastructure/constructs/storage.py
@@ -1,8 +1,8 @@
 """
 Geostore AWS resources definitions.
 """
-from aws_cdk import aws_dynamodb, aws_s3, aws_ssm
-from aws_cdk.core import Construct, Tags
+from aws_cdk import Tags, aws_dynamodb, aws_s3, aws_ssm
+from constructs import Construct
 
 from geostore.datasets_model import DatasetsTitleIdx
 from geostore.parameter_store import ParameterName

--- a/infrastructure/constructs/table.py
+++ b/infrastructure/constructs/table.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from aws_cdk import aws_dynamodb, aws_ssm
-from aws_cdk.core import Construct
+from constructs import Construct
 
 from geostore.parameter_store import ParameterName
 

--- a/infrastructure/constructs/task_job_definition.py
+++ b/infrastructure/constructs/task_job_definition.py
@@ -1,7 +1,7 @@
 from os.path import join
 
-from aws_cdk import aws_batch, aws_ecs, aws_iam
-from aws_cdk.core import Construct
+from aws_cdk import aws_batch_alpha, aws_ecs, aws_iam
+from constructs import Construct
 
 from geostore.aws_keys import AWS_DEFAULT_REGION_KEY
 from geostore.environment import ENV_NAME_VARIABLE_NAME, is_production
@@ -9,7 +9,7 @@ from geostore.environment import ENV_NAME_VARIABLE_NAME, is_production
 from .backend import BACKEND_DIRECTORY
 
 
-class TaskJobDefinition(aws_batch.JobDefinition):
+class TaskJobDefinition(aws_batch_alpha.JobDefinition):
     def __init__(
         self,
         scope: Construct,
@@ -30,7 +30,7 @@ class TaskJobDefinition(aws_batch.JobDefinition):
             file=join(BACKEND_DIRECTORY, "Dockerfile"),
         )
 
-        container = aws_batch.JobDefinitionContainer(
+        container = aws_batch_alpha.JobDefinitionContainer(
             image=image,
             job_role=job_role,
             memory_limit_mib=batch_job_definition_memory_limit,

--- a/infrastructure/networking_stack.py
+++ b/infrastructure/networking_stack.py
@@ -1,5 +1,5 @@
-from aws_cdk import aws_ec2
-from aws_cdk.core import Construct, Stack, Tags
+from aws_cdk import Stack, Tags, aws_ec2
+from constructs import Construct
 
 from geostore.environment import is_production
 
@@ -22,11 +22,13 @@ class NetworkingStack(Stack):
                     cidr_mask=27, name="public", subnet_type=aws_ec2.SubnetType.PUBLIC
                 ),
                 aws_ec2.SubnetConfiguration(
-                    cidr_mask=20, name="ecs-cluster", subnet_type=aws_ec2.SubnetType.PRIVATE
+                    cidr_mask=20,
+                    name="ecs-cluster",
+                    subnet_type=aws_ec2.SubnetType.PRIVATE_ISOLATED,
                 ),
                 aws_ec2.SubnetConfiguration(
                     name="reserved",
-                    subnet_type=aws_ec2.SubnetType.PRIVATE,
+                    subnet_type=aws_ec2.SubnetType.PRIVATE_ISOLATED,
                     reserved=True,
                 ),
             ],

--- a/poetry.lock
+++ b/poetry.lock
@@ -61,1183 +61,44 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
-name = "aws-cdk.assets"
-version = "1.149.0"
-description = "This module is deprecated. All types are now available under the core module"
+name = "aws-cdk-lib"
+version = "2.24.0"
+description = "Version 2 of the AWS Cloud Development Kit library"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = "~=3.7"
 
 [package.dependencies]
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
+constructs = ">=10.0.0,<11.0.0"
+jsii = ">=1.58.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
-name = "aws-cdk.aws-acmpca"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::ACMPCA"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-apigateway"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::ApiGateway"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-cognito" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.aws-s3-assets" = "1.149.0"
-"aws-cdk.aws-stepfunctions" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-applicationautoscaling"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::ApplicationAutoScaling"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-autoscaling-common" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-autoscaling"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::AutoScaling"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-autoscaling-common" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-elasticloadbalancing" = "1.149.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-autoscaling-common"
-version = "1.149.0"
-description = "Common implementation package for @aws-cdk/aws-autoscaling and @aws-cdk/aws-applicationautoscaling"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-autoscaling-hooktargets"
-version = "1.149.0"
-description = "Lifecycle hook for AWS AutoScaling"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-autoscaling" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.aws-sns-subscriptions" = "1.149.0"
-"aws-cdk.aws-sqs" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-batch"
-version = "1.149.0"
+name = "aws-cdk.aws-batch-alpha"
+version = "2.24.0a0"
 description = "The CDK Construct Library for AWS::Batch"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = "~=3.7"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-ecr" = "1.149.0"
-"aws-cdk.aws-ecs" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-secretsmanager" = "1.149.0"
-"aws-cdk.aws-ssm" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
+aws-cdk-lib = ">=2.24.0,<3.0.0"
+constructs = ">=10.0.0,<11.0.0"
+jsii = ">=1.58.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
-name = "aws-cdk.aws-certificatemanager"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::CertificateManager"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-acmpca" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-route53" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-cloudformation"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::CloudFormation"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-cloudfront"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::CloudFront"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.aws-ssm" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-cloudwatch"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::CloudWatch"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-codebuild"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::CodeBuild"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.assets" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-codecommit" = "1.149.0"
-"aws-cdk.aws-codestarnotifications" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-ecr" = "1.149.0"
-"aws-cdk.aws-ecr-assets" = "1.149.0"
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.aws-s3-assets" = "1.149.0"
-"aws-cdk.aws-secretsmanager" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.region-info" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-codecommit"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::CodeCommit"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-codestarnotifications" = "1.149.0"
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-s3-assets" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-codeguruprofiler"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::CodeGuruProfiler"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-codepipeline"
-version = "1.149.0"
-description = "Better interface to AWS Code Pipeline"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-codestarnotifications" = "1.149.0"
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-codestarnotifications"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::CodeStarNotifications"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-cognito"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::Cognito"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.custom-resources" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-dynamodb"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::DynamoDB"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kinesis" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.custom-resources" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-ec2"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::EC2"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.aws-s3-assets" = "1.149.0"
-"aws-cdk.aws-ssm" = "1.149.0"
-"aws-cdk.cloud-assembly-schema" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-"aws-cdk.region-info" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-ecr"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::ECR"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-ecr-assets"
-version = "1.149.0"
-description = "Docker image assets deployed to ECR"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.assets" = "1.149.0"
-"aws-cdk.aws-ecr" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-ecs"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::ECS"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.149.0"
-"aws-cdk.aws-autoscaling" = "1.149.0"
-"aws-cdk.aws-autoscaling-hooktargets" = "1.149.0"
-"aws-cdk.aws-certificatemanager" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-ecr" = "1.149.0"
-"aws-cdk.aws-ecr-assets" = "1.149.0"
-"aws-cdk.aws-elasticloadbalancing" = "1.149.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.aws-route53" = "1.149.0"
-"aws-cdk.aws-route53-targets" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.aws-s3-assets" = "1.149.0"
-"aws-cdk.aws-secretsmanager" = "1.149.0"
-"aws-cdk.aws-servicediscovery" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.aws-sqs" = "1.149.0"
-"aws-cdk.aws-ssm" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-efs"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::EFS"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.cloud-assembly-schema" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-eks"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::EKS"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-autoscaling" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-s3-assets" = "1.149.0"
-"aws-cdk.aws-ssm" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.custom-resources" = "1.149.0"
-"aws-cdk.lambda-layer-awscli" = "1.149.0"
-"aws-cdk.lambda-layer-kubectl" = "1.149.0"
-"aws-cdk.lambda-layer-node-proxy-agent" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-elasticloadbalancing"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::ElasticLoadBalancing"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-elasticloadbalancingv2"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::ElasticLoadBalancingV2"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.cloud-assembly-schema" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-"aws-cdk.region-info" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-events"
-version = "1.149.0"
-description = "Amazon EventBridge Construct Library"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-events-targets"
-version = "1.149.0"
-description = "Event targets for Amazon EventBridge"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-apigateway" = "1.149.0"
-"aws-cdk.aws-autoscaling" = "1.149.0"
-"aws-cdk.aws-codebuild" = "1.149.0"
-"aws-cdk.aws-codepipeline" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-ecs" = "1.149.0"
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kinesis" = "1.149.0"
-"aws-cdk.aws-kinesisfirehose" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.aws-sns-subscriptions" = "1.149.0"
-"aws-cdk.aws-sqs" = "1.149.0"
-"aws-cdk.aws-stepfunctions" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.custom-resources" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-globalaccelerator"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::GlobalAccelerator"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.custom-resources" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-iam"
-version = "1.149.0"
-description = "CDK routines for easily assigning correct and minimal IAM permissions"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.region-info" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-kinesis"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::Kinesis"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-kinesisfirehose"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::KinesisFirehose"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kinesis" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.region-info" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-kms"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::KMS"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.cloud-assembly-schema" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-lambda"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::Lambda"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-codeguruprofiler" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-ecr" = "1.149.0"
-"aws-cdk.aws-ecr-assets" = "1.149.0"
-"aws-cdk.aws-efs" = "1.149.0"
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.aws-s3-assets" = "1.149.0"
-"aws-cdk.aws-signer" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.aws-sqs" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-"aws-cdk.region-info" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-lambda-event-sources"
-version = "1.149.0"
-description = "Event sources for AWS Lambda"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-apigateway" = "1.149.0"
-"aws-cdk.aws-dynamodb" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kinesis" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.aws-s3-notifications" = "1.149.0"
-"aws-cdk.aws-secretsmanager" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.aws-sns-subscriptions" = "1.149.0"
-"aws-cdk.aws-sqs" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-lambda-python"
-version = "1.149.0"
+name = "aws-cdk.aws-lambda-python-alpha"
+version = "2.24.0a0"
 description = "The CDK Construct Library for AWS Lambda in Python"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = "~=3.7"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-logs"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::Logs"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-s3-assets" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-route53"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::Route53"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.cloud-assembly-schema" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.custom-resources" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-route53-targets"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS Route53 Alias Targets"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-apigateway" = "1.149.0"
-"aws-cdk.aws-cloudfront" = "1.149.0"
-"aws-cdk.aws-cognito" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-elasticloadbalancing" = "1.149.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.149.0"
-"aws-cdk.aws-globalaccelerator" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-route53" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.region-info" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-s3"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::S3"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-s3-assets"
-version = "1.149.0"
-description = "Deploy local files and directories to S3"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.assets" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-s3-notifications"
-version = "1.149.0"
-description = "Bucket Notifications API for AWS S3"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.aws-sqs" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-sam"
-version = "1.149.0"
-description = "The CDK Construct Library for the AWS Serverless Application Model (SAM) resources"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-secretsmanager"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::SecretsManager"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-sam" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-servicediscovery"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::ServiceDiscovery"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.149.0"
-"aws-cdk.aws-route53" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-signer"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::Signer"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-sns"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::SNS"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-codestarnotifications" = "1.149.0"
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-sqs" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-sns-subscriptions"
-version = "1.149.0"
-description = "CDK Subscription Constructs for AWS SNS"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.aws-sqs" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-sqs"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::SQS"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-ssm"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::SSM"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.cloud-assembly-schema" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-stepfunctions"
-version = "1.149.0"
-description = "The CDK Construct Library for AWS::StepFunctions"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.aws-stepfunctions-tasks"
-version = "1.149.0"
-description = "Task integrations for AWS StepFunctions"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-apigateway" = "1.149.0"
-"aws-cdk.aws-cloudwatch" = "1.149.0"
-"aws-cdk.aws-codebuild" = "1.149.0"
-"aws-cdk.aws-dynamodb" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-ecr" = "1.149.0"
-"aws-cdk.aws-ecr-assets" = "1.149.0"
-"aws-cdk.aws-ecs" = "1.149.0"
-"aws-cdk.aws-eks" = "1.149.0"
-"aws-cdk.aws-events" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-kms" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.aws-s3" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.aws-sqs" = "1.149.0"
-"aws-cdk.aws-stepfunctions" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-"aws-cdk.custom-resources" = "1.149.0"
-"aws-cdk.lambda-layer-awscli" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.cloud-assembly-schema"
-version = "1.149.0"
-description = "Cloud Assembly Schema"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.core"
-version = "1.149.0"
-description = "AWS Cloud Development Kit Core Library"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.cloud-assembly-schema" = "1.149.0"
-"aws-cdk.cx-api" = "1.149.0"
-"aws-cdk.region-info" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.custom-resources"
-version = "1.149.0"
-description = "Constructs for implementing CDK custom resources"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-cloudformation" = "1.149.0"
-"aws-cdk.aws-ec2" = "1.149.0"
-"aws-cdk.aws-iam" = "1.149.0"
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.aws-logs" = "1.149.0"
-"aws-cdk.aws-sns" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.cx-api"
-version = "1.149.0"
-description = "Cloud executable protocol"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.cloud-assembly-schema" = "1.149.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.lambda-layer-awscli"
-version = "1.149.0"
-description = "An AWS Lambda layer that contains the AWS CLI"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.lambda-layer-kubectl"
-version = "1.149.0"
-description = "An AWS Lambda layer that contains the `kubectl` and `helm`"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.lambda-layer-node-proxy-agent"
-version = "1.149.0"
-description = "An AWS Lambda layer that contains the `proxy-agent` NPM dependency"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-"aws-cdk.aws-lambda" = "1.149.0"
-"aws-cdk.core" = "1.149.0"
-constructs = ">=3.3.69,<4.0.0"
-jsii = ">=1.54.0,<2.0.0"
-publication = ">=0.0.3"
-
-[[package]]
-name = "aws-cdk.region-info"
-version = "1.149.0"
-description = "AWS region information, such as service principal names"
-category = "main"
-optional = true
-python-versions = ">=3.6"
-
-[package.dependencies]
-jsii = ">=1.54.0,<2.0.0"
+aws-cdk-lib = ">=2.24.0,<3.0.0"
+constructs = ">=10.0.0,<11.0.0"
+jsii = ">=1.58.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
@@ -1301,8 +162,8 @@ s3transfer = ">=0.3.0,<0.4.0"
 
 [[package]]
 name = "boto3-stubs"
-version = "1.22.12"
-description = "Type annotations for boto3 1.22.12 generated with mypy-boto3-builder 7.5.14"
+version = "1.22.13"
+description = "Type annotations for boto3 1.22.13 generated with mypy-boto3-builder 7.5.14"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
@@ -1711,19 +572,19 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "constructs"
-version = "3.3.246"
-description = "A programming model for composable configuration"
+version = "10.1.7"
+description = "A programming model for software-defined state"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = "~=3.7"
 
 [package.dependencies]
-jsii = ">=1.55.1,<2.0.0"
+jsii = ">=1.58.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "coverage"
-version = "6.3.2"
+version = "6.3.3"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -2001,15 +862,15 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "jsii"
-version = "1.55.1"
+version = "1.58.0"
 description = "Python client for jsii runtime"
 category = "main"
 optional = true
-python-versions = "~=3.6"
+python-versions = "~=3.7"
 
 [package.dependencies]
 attrs = ">=21.2,<22.0"
-cattrs = {version = ">=1.8,<1.11", markers = "python_version >= \"3.7\""}
+cattrs = ">=1.8,<22.2"
 python-dateutil = "*"
 typing-extensions = ">=3.7,<5.0"
 
@@ -2023,7 +884,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "jsonschema"
-version = "4.4.0"
+version = "4.5.1"
 description = "An implementation of JSON Schema validation for Python"
 category = "main"
 optional = true
@@ -2966,7 +1827,7 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [extras]
-cdk = ["aws-cdk.aws-batch", "aws-cdk.aws-dynamodb", "aws-cdk.aws-ec2", "aws-cdk.aws-ecr", "aws-cdk.aws-ecr_assets", "aws-cdk.aws-ecs", "aws-cdk.aws-events", "aws-cdk.aws-events-targets", "aws-cdk.aws-iam", "aws-cdk.aws-lambda", "aws-cdk.aws-lambda-event-sources", "aws-cdk.aws-lambda-python", "aws-cdk.aws-s3", "aws-cdk.aws-sns", "aws-cdk.aws-stepfunctions", "aws-cdk.aws-stepfunctions_tasks", "awscli", "cattrs"]
+cdk = ["aws-cdk.aws-batch-alpha", "aws-cdk.aws-lambda-python-alpha", "aws-cdk-lib", "awscli", "cattrs"]
 check_files_checksums = ["linz-logger", "multihash", "pynamodb"]
 check_stac_metadata = ["jsonschema", "linz-logger", "pynamodb", "strict-rfc3339"]
 content_iterator = ["jsonschema", "linz-logger", "pynamodb"]
@@ -2985,7 +1846,7 @@ validation_summary = ["jsonschema", "linz-logger", "pynamodb"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "5c39ddf62294dfa399da3fd05135d744b82bb6f31b430d3100227446a48c15fc"
+content-hash = "fdcf8f660c6f5f21afc1aa320600fc58a859aec3824dc08632aab989c2b9c92d"
 
 [metadata.files]
 appdirs = [
@@ -3012,249 +1873,17 @@ attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
-"aws-cdk.assets" = [
-    {file = "aws-cdk.assets-1.149.0.tar.gz", hash = "sha256:e1b083b8bd75b347622438601a2a4a10b70bfb96b10d364218684aa88c021af0"},
-    {file = "aws_cdk.assets-1.149.0-py3-none-any.whl", hash = "sha256:34d81625da167c4a831f5121460c43fc20af63cdb67cab529f12ad75f85bb106"},
+aws-cdk-lib = [
+    {file = "aws-cdk-lib-2.24.0.tar.gz", hash = "sha256:eb3be5405c6d316ee8903a12cfef64f15266fef08a652829c02f962595176e73"},
+    {file = "aws_cdk_lib-2.24.0-py3-none-any.whl", hash = "sha256:36aa38b1a9d5e0036b40f7610c7dcaaec1194e1f8fbb7bf2f789cf066d1b05b1"},
 ]
-"aws-cdk.aws-acmpca" = [
-    {file = "aws-cdk.aws-acmpca-1.149.0.tar.gz", hash = "sha256:30505f59b0073a241d33785d4be05817f806ff7393810e98e7cc16721dc75952"},
-    {file = "aws_cdk.aws_acmpca-1.149.0-py3-none-any.whl", hash = "sha256:ca1ad9c621b164194e79aab48f316bb90182bb104f374e0449083c63c99febc6"},
+"aws-cdk.aws-batch-alpha" = [
+    {file = "aws-cdk.aws-batch-alpha-2.24.0a0.tar.gz", hash = "sha256:40c7e618d069b5054f3dfde43835a1c4acf8567a481613bd3ce4a95f79619fe0"},
+    {file = "aws_cdk.aws_batch_alpha-2.24.0a0-py3-none-any.whl", hash = "sha256:cb5264022fd550299bfca6431abf48454b35e982f8f0362f554a9d9b388096f3"},
 ]
-"aws-cdk.aws-apigateway" = [
-    {file = "aws-cdk.aws-apigateway-1.149.0.tar.gz", hash = "sha256:f8e77a7fef8a38c1445bdedd933484186ec414c7e6f2a376d4413e2f321f699d"},
-    {file = "aws_cdk.aws_apigateway-1.149.0-py3-none-any.whl", hash = "sha256:2cd1e56c8ea7068f789f326170533b650ca345346bf164972a19bb87c4eea8ad"},
-]
-"aws-cdk.aws-applicationautoscaling" = [
-    {file = "aws-cdk.aws-applicationautoscaling-1.149.0.tar.gz", hash = "sha256:088fd04b73ecf97cabe40751e7e6fd55221604836f332514839c13b2fa6f2f77"},
-    {file = "aws_cdk.aws_applicationautoscaling-1.149.0-py3-none-any.whl", hash = "sha256:4aa972f28551134fb2987931e0055bdab0626faab8a2e6539fe2c309100d4a22"},
-]
-"aws-cdk.aws-autoscaling" = [
-    {file = "aws-cdk.aws-autoscaling-1.149.0.tar.gz", hash = "sha256:c41a425e0ceafedf4395e75b3ada6d960684015358c06a95eded04355e3de180"},
-    {file = "aws_cdk.aws_autoscaling-1.149.0-py3-none-any.whl", hash = "sha256:7f74a456890e081ee3dec337a4145090ca05c030d7f929d7b64c091dd5327303"},
-]
-"aws-cdk.aws-autoscaling-common" = [
-    {file = "aws-cdk.aws-autoscaling-common-1.149.0.tar.gz", hash = "sha256:469b9423f6ca91ccdfc219605b8d000fb0d18ab4b6c984cb66f9c8a52587b5c7"},
-    {file = "aws_cdk.aws_autoscaling_common-1.149.0-py3-none-any.whl", hash = "sha256:8aff027eab3f6a33e50ddf97242408275d65e7e919b5f516138c420fd6659da8"},
-]
-"aws-cdk.aws-autoscaling-hooktargets" = [
-    {file = "aws-cdk.aws-autoscaling-hooktargets-1.149.0.tar.gz", hash = "sha256:ea17c50be3111a319ecfe014a6a4e60f6ee7020bf652d84180dbf621d997d9cc"},
-    {file = "aws_cdk.aws_autoscaling_hooktargets-1.149.0-py3-none-any.whl", hash = "sha256:8bed3bd1459e182800edf07c076bd25216f36069fc097e34ce9f8e6c93f3f1f1"},
-]
-"aws-cdk.aws-batch" = [
-    {file = "aws-cdk.aws-batch-1.149.0.tar.gz", hash = "sha256:20abe9b610ae49ba7752ae4382ba5690dc1756b0b7a5f89cc7b900cf61a5273d"},
-    {file = "aws_cdk.aws_batch-1.149.0-py3-none-any.whl", hash = "sha256:0e573c55a740ec305bde5d64131b777ac41b25a3bc1db6ea35e1fddaa31351d7"},
-]
-"aws-cdk.aws-certificatemanager" = [
-    {file = "aws-cdk.aws-certificatemanager-1.149.0.tar.gz", hash = "sha256:51a40995b405aebc25342eda2a9335926cb6619e2595c48b1b92760ec1b8023a"},
-    {file = "aws_cdk.aws_certificatemanager-1.149.0-py3-none-any.whl", hash = "sha256:6628efb35ee11fceb71b01c9d7a5790721ce51b7e2aa15ad2750a3e9e605637f"},
-]
-"aws-cdk.aws-cloudformation" = [
-    {file = "aws-cdk.aws-cloudformation-1.149.0.tar.gz", hash = "sha256:e8d872ea7147fa012a1d1c3770e73d9b155aa90c59e7523ca65c93c34adfe110"},
-    {file = "aws_cdk.aws_cloudformation-1.149.0-py3-none-any.whl", hash = "sha256:4792dad3a918ff4120c54c20038ae417cc47a4cd631cd55b9fddb1bbf074275b"},
-]
-"aws-cdk.aws-cloudfront" = [
-    {file = "aws-cdk.aws-cloudfront-1.149.0.tar.gz", hash = "sha256:436a05f30974c7f0445db92b9485db9f05d49fcd2098bd0290f27d033bda5130"},
-    {file = "aws_cdk.aws_cloudfront-1.149.0-py3-none-any.whl", hash = "sha256:b034d5ed6afd963ea4de766f8e4c926b0679c5fc3d927805ae89287ea2535a6c"},
-]
-"aws-cdk.aws-cloudwatch" = [
-    {file = "aws-cdk.aws-cloudwatch-1.149.0.tar.gz", hash = "sha256:1798a67094abca072e131655f8a2ea08b5075e558a3cf7d5629ea05ab6b72ae5"},
-    {file = "aws_cdk.aws_cloudwatch-1.149.0-py3-none-any.whl", hash = "sha256:1b1386cca493e2c95eaf0c8402da4ab93c3d4945f16c59f25fcece29cd418b91"},
-]
-"aws-cdk.aws-codebuild" = [
-    {file = "aws-cdk.aws-codebuild-1.149.0.tar.gz", hash = "sha256:7d9247c0278afa6c7ce69a460fe6d1d047278ef5d072c2dc005ac6043d67faf4"},
-    {file = "aws_cdk.aws_codebuild-1.149.0-py3-none-any.whl", hash = "sha256:da7222ceb86b3dc1bf40a7bebf6faef887514f5c7374c48f335b642a34b7e922"},
-]
-"aws-cdk.aws-codecommit" = [
-    {file = "aws-cdk.aws-codecommit-1.149.0.tar.gz", hash = "sha256:1cabf2f979bf0652dda395368a94dd21688a2d8db588af26b0427525c01f89fe"},
-    {file = "aws_cdk.aws_codecommit-1.149.0-py3-none-any.whl", hash = "sha256:e7663b390481db3e9df23706c890d37f3122dddcf8d467acdb40daa5fae63467"},
-]
-"aws-cdk.aws-codeguruprofiler" = [
-    {file = "aws-cdk.aws-codeguruprofiler-1.149.0.tar.gz", hash = "sha256:84ad23634c42e9dab971e5141386ea2356a2ff0a3386404a628b1ef92e2e1ae0"},
-    {file = "aws_cdk.aws_codeguruprofiler-1.149.0-py3-none-any.whl", hash = "sha256:c0695f8947444e8a65394e29b30e7d3e1f664c11866e7e0a8c22d2b1d5a298ad"},
-]
-"aws-cdk.aws-codepipeline" = [
-    {file = "aws-cdk.aws-codepipeline-1.149.0.tar.gz", hash = "sha256:2b2ca527e2aa23519dca2563d88251f2874050c175c4d9baab893a892fdd1893"},
-    {file = "aws_cdk.aws_codepipeline-1.149.0-py3-none-any.whl", hash = "sha256:154d9fbb0bfde662df331bee792f21e185b1c502fe68a4aa291b198e9a85a47d"},
-]
-"aws-cdk.aws-codestarnotifications" = [
-    {file = "aws-cdk.aws-codestarnotifications-1.149.0.tar.gz", hash = "sha256:92ec815622037c54523f3ddc0b847a256b1ebc2a537dea169531de3930d08418"},
-    {file = "aws_cdk.aws_codestarnotifications-1.149.0-py3-none-any.whl", hash = "sha256:ba36ef3caab5aa62d312b9b598193fc21358b89cbfd2d1a2b9102710704eb1c8"},
-]
-"aws-cdk.aws-cognito" = [
-    {file = "aws-cdk.aws-cognito-1.149.0.tar.gz", hash = "sha256:af7f19692a22e261a0de9263b670efb4ea955a48372363405bca2bf33ede4a1f"},
-    {file = "aws_cdk.aws_cognito-1.149.0-py3-none-any.whl", hash = "sha256:bb791e79fcef9121c2fa8ef1b6c705bbf7b73d65f228cc45f01bea9ae6fe62ad"},
-]
-"aws-cdk.aws-dynamodb" = [
-    {file = "aws-cdk.aws-dynamodb-1.149.0.tar.gz", hash = "sha256:f244e59007d669aa47eadfad590f509864fb28d9e49d82a1df1e3d581efa96b0"},
-    {file = "aws_cdk.aws_dynamodb-1.149.0-py3-none-any.whl", hash = "sha256:a37b1a89e9d284b027c3de9de4f79ef660216c4ea0b85f3f618109dd66939202"},
-]
-"aws-cdk.aws-ec2" = [
-    {file = "aws-cdk.aws-ec2-1.149.0.tar.gz", hash = "sha256:51d40de29fa1a91bea02cc6b21f0ad5b32196e716afbbb95b739aaebd4ecf9c7"},
-    {file = "aws_cdk.aws_ec2-1.149.0-py3-none-any.whl", hash = "sha256:9abe40757d3b2386f7ac5d5c40aab3b7968b0ad337e1c88cea28faa182c332bb"},
-]
-"aws-cdk.aws-ecr" = [
-    {file = "aws-cdk.aws-ecr-1.149.0.tar.gz", hash = "sha256:fb1e1284b12c632574b2d65a81bf76698a8dbd771dbf917178dc437f5b75b1ce"},
-    {file = "aws_cdk.aws_ecr-1.149.0-py3-none-any.whl", hash = "sha256:b7a240c0718d037b90f208b6cd44c591cae0309fe3e73ceb8b08b3ca59007a16"},
-]
-"aws-cdk.aws-ecr-assets" = [
-    {file = "aws-cdk.aws-ecr-assets-1.149.0.tar.gz", hash = "sha256:3a2fd59101494d149d089ee846b0b50c45ca3d448429b343a4d3e65f0a27d450"},
-    {file = "aws_cdk.aws_ecr_assets-1.149.0-py3-none-any.whl", hash = "sha256:6b18061a4352f2530dad79f09b0557303175a7491bafeafdad22c1779a3c6f29"},
-]
-"aws-cdk.aws-ecs" = [
-    {file = "aws-cdk.aws-ecs-1.149.0.tar.gz", hash = "sha256:c73b575f7fab779191aa02b846d93edd1b1cac968f0b1561b03e1f61c4733172"},
-    {file = "aws_cdk.aws_ecs-1.149.0-py3-none-any.whl", hash = "sha256:7505fa75ce3dd31e50ea4dc50b2916277d9c63a94d8fbdf3bfb3e2fcae998325"},
-]
-"aws-cdk.aws-efs" = [
-    {file = "aws-cdk.aws-efs-1.149.0.tar.gz", hash = "sha256:4833df079613a7cfc47bc110924a6eb4020bc653b2118b98d3ee3b147e7cbf02"},
-    {file = "aws_cdk.aws_efs-1.149.0-py3-none-any.whl", hash = "sha256:a5199242c90d4229ae83effa491032ea2156c78d183c09c05d75dca3fae16c6b"},
-]
-"aws-cdk.aws-eks" = [
-    {file = "aws-cdk.aws-eks-1.149.0.tar.gz", hash = "sha256:9520a8b9729c03a80c14ef7ea39d6e107ad5d286f0c05aa3f686c86ea770076d"},
-    {file = "aws_cdk.aws_eks-1.149.0-py3-none-any.whl", hash = "sha256:6a099344306d1ae554f9495ec4335c57c1216050b57cf9130c1b6be7aae5c500"},
-]
-"aws-cdk.aws-elasticloadbalancing" = [
-    {file = "aws-cdk.aws-elasticloadbalancing-1.149.0.tar.gz", hash = "sha256:7cdd7ef788c9b9a90b4ecab1305b9593aa9965b0e99997e295998e0b0480d30f"},
-    {file = "aws_cdk.aws_elasticloadbalancing-1.149.0-py3-none-any.whl", hash = "sha256:2ed72fe845a2c864e2e4ff823299ef404c2c73b417e1759ca34c6a3c8ef4f386"},
-]
-"aws-cdk.aws-elasticloadbalancingv2" = [
-    {file = "aws-cdk.aws-elasticloadbalancingv2-1.149.0.tar.gz", hash = "sha256:77dcc88ba9fa00421146060f43374097edae577081401c8197720fdca36bd299"},
-    {file = "aws_cdk.aws_elasticloadbalancingv2-1.149.0-py3-none-any.whl", hash = "sha256:288a3d30a40b974fed215f4de884045ce3795e35426331ed1007955602ec48bc"},
-]
-"aws-cdk.aws-events" = [
-    {file = "aws-cdk.aws-events-1.149.0.tar.gz", hash = "sha256:6d0fc357be8743e777360c208f8c6c909ea7a95fadd22339bf88fdabe6d7b803"},
-    {file = "aws_cdk.aws_events-1.149.0-py3-none-any.whl", hash = "sha256:0dda83749c0980d1ea7dd8e5002ae838bf7fb9844980a2a4c426603fe28bbd01"},
-]
-"aws-cdk.aws-events-targets" = [
-    {file = "aws-cdk.aws-events-targets-1.149.0.tar.gz", hash = "sha256:b1fbaad07561e609aa2601b3e875cbfdd4c653a408fdd24468f4d7cd43d28cc4"},
-    {file = "aws_cdk.aws_events_targets-1.149.0-py3-none-any.whl", hash = "sha256:632d5a58104e7215449810b757143035d448b854719d69df95498db6ead795f1"},
-]
-"aws-cdk.aws-globalaccelerator" = [
-    {file = "aws-cdk.aws-globalaccelerator-1.149.0.tar.gz", hash = "sha256:ddba7c9520f42e75511ef9462fefcce17a07ff00c523e6783b75b8a4ed1857f8"},
-    {file = "aws_cdk.aws_globalaccelerator-1.149.0-py3-none-any.whl", hash = "sha256:d76e8c1034f2658b1e5db97b5b42b9764ee85eeb7fe4d2012086326e908d4366"},
-]
-"aws-cdk.aws-iam" = [
-    {file = "aws-cdk.aws-iam-1.149.0.tar.gz", hash = "sha256:0c82ee4c69adac818464d501cf165cb2d72289140a83a32ff6ad949e25aedc25"},
-    {file = "aws_cdk.aws_iam-1.149.0-py3-none-any.whl", hash = "sha256:46b60ef75d6f0d285c76217552fc8d2c6855d70ba2a64e9fedf0f90c454a6f04"},
-]
-"aws-cdk.aws-kinesis" = [
-    {file = "aws-cdk.aws-kinesis-1.149.0.tar.gz", hash = "sha256:6ee89570f13e0fcebfbb0000d48ab5f4f4915ccefbb216f09b1fd5a951000a3f"},
-    {file = "aws_cdk.aws_kinesis-1.149.0-py3-none-any.whl", hash = "sha256:5b44538db8e6f9f18e62799ee874e49aeda4abb84bb1fe7fb5780b42f5e38bbb"},
-]
-"aws-cdk.aws-kinesisfirehose" = [
-    {file = "aws-cdk.aws-kinesisfirehose-1.149.0.tar.gz", hash = "sha256:2ec14749442defd9e1644cfd565743aef606f6d83507ffc271e6217f453f54bd"},
-    {file = "aws_cdk.aws_kinesisfirehose-1.149.0-py3-none-any.whl", hash = "sha256:3cd18c385c9bd79c0b908c805a56355d6ae9c96674638692e288a4fe9f133752"},
-]
-"aws-cdk.aws-kms" = [
-    {file = "aws-cdk.aws-kms-1.149.0.tar.gz", hash = "sha256:6e5ab2edf4dddb6eff910e35222fe6df530f02bcc3b0010bfdeacb1f2497ba4c"},
-    {file = "aws_cdk.aws_kms-1.149.0-py3-none-any.whl", hash = "sha256:569853b187105f44b6a6b29717a307842e319de47c360ba0d42863bfcbd08ed1"},
-]
-"aws-cdk.aws-lambda" = [
-    {file = "aws-cdk.aws-lambda-1.149.0.tar.gz", hash = "sha256:6b2ba72cf9104566e88d82cfee81e793e3854135ac6ca4603853e189698f026b"},
-    {file = "aws_cdk.aws_lambda-1.149.0-py3-none-any.whl", hash = "sha256:0f2f2ac4e18b3795a7db71330927a5cda21ac5901fc79dad68107538591e7653"},
-]
-"aws-cdk.aws-lambda-event-sources" = [
-    {file = "aws-cdk.aws-lambda-event-sources-1.149.0.tar.gz", hash = "sha256:acd5c2daff8f6b0c3bf8feda7666daff6e7ce45b5c26b51dc48d651471d2a288"},
-    {file = "aws_cdk.aws_lambda_event_sources-1.149.0-py3-none-any.whl", hash = "sha256:32396a4cad7e9cf0750869822bce96f215c22bda6ed5793a73eb4177806a0249"},
-]
-"aws-cdk.aws-lambda-python" = [
-    {file = "aws-cdk.aws-lambda-python-1.149.0.tar.gz", hash = "sha256:990527e4e25fba88f26432435dd0e4409bfb43dca541fcd151d47f7a52856cbf"},
-    {file = "aws_cdk.aws_lambda_python-1.149.0-py3-none-any.whl", hash = "sha256:de486ee985486d2b43528e39db2b73176bc0de97e514980475481657d59089cb"},
-]
-"aws-cdk.aws-logs" = [
-    {file = "aws-cdk.aws-logs-1.149.0.tar.gz", hash = "sha256:62ec09e1144276389bfeee8aaad89eacbb04f6c6561793a93c20834ddf8e8074"},
-    {file = "aws_cdk.aws_logs-1.149.0-py3-none-any.whl", hash = "sha256:8960c2236a543d208bf879c1129162dec92cfa0749af47b78a16be5970aab366"},
-]
-"aws-cdk.aws-route53" = [
-    {file = "aws-cdk.aws-route53-1.149.0.tar.gz", hash = "sha256:6a09282f47087baa37a93fac69a18c7af9ad367037c44ceea55f0af20aac1ab1"},
-    {file = "aws_cdk.aws_route53-1.149.0-py3-none-any.whl", hash = "sha256:a98e8e6270289b3f4f2000e3f1a19ecf90ceabd5987c597a46b4265c0e27402c"},
-]
-"aws-cdk.aws-route53-targets" = [
-    {file = "aws-cdk.aws-route53-targets-1.149.0.tar.gz", hash = "sha256:0c0c63997a98c488fddcacfb26edbbc171c708c5750a68bdf32f48f2123542ef"},
-    {file = "aws_cdk.aws_route53_targets-1.149.0-py3-none-any.whl", hash = "sha256:442e7bc31106cd750f7c0bc0bf68175d313985f9ca4d1b750e334d194e52ff28"},
-]
-"aws-cdk.aws-s3" = [
-    {file = "aws-cdk.aws-s3-1.149.0.tar.gz", hash = "sha256:3c03426994506847a5417c304d380721885b8a0c0a9288f086c8955f119579ac"},
-    {file = "aws_cdk.aws_s3-1.149.0-py3-none-any.whl", hash = "sha256:fe227d2f3f70540d730ddd26dc4f2ce8e166c20089a03c996f67d6223af87004"},
-]
-"aws-cdk.aws-s3-assets" = [
-    {file = "aws-cdk.aws-s3-assets-1.149.0.tar.gz", hash = "sha256:5c41e73fc76813deedb2600cf11eb8eead9dbdde6dcb5b69405d09ddf6a2feeb"},
-    {file = "aws_cdk.aws_s3_assets-1.149.0-py3-none-any.whl", hash = "sha256:9a35d4afa4de00d6466ee98a60be5d13cb5df28f37c5f2486d7d97df7a47d88a"},
-]
-"aws-cdk.aws-s3-notifications" = [
-    {file = "aws-cdk.aws-s3-notifications-1.149.0.tar.gz", hash = "sha256:af5df23fa23ae981bad68b96fe39d5b4fdfd8e9bd443c67c5aadec9f0b96c5fc"},
-    {file = "aws_cdk.aws_s3_notifications-1.149.0-py3-none-any.whl", hash = "sha256:086e0ad88246c03b40f79a39bf84fba9f22a0accd61ba5d62bcda0a2718da522"},
-]
-"aws-cdk.aws-sam" = [
-    {file = "aws-cdk.aws-sam-1.149.0.tar.gz", hash = "sha256:f9f7a33baaf4c150c4f53e54cdd605f32f151fac88ebd557d77ab6624fa3680f"},
-    {file = "aws_cdk.aws_sam-1.149.0-py3-none-any.whl", hash = "sha256:970daa7637f2f667345cd6c816ffda46cd85032554758c26ee8dd33ad8fccf65"},
-]
-"aws-cdk.aws-secretsmanager" = [
-    {file = "aws-cdk.aws-secretsmanager-1.149.0.tar.gz", hash = "sha256:f97f12a3ed81a5d4012bd91e6bd028df96eeddb4aff474450879f35eb52eeb52"},
-    {file = "aws_cdk.aws_secretsmanager-1.149.0-py3-none-any.whl", hash = "sha256:ac40473beb9ab2e1be98fd10bb09d20a555df1ea84546b1fe386138c6d254619"},
-]
-"aws-cdk.aws-servicediscovery" = [
-    {file = "aws-cdk.aws-servicediscovery-1.149.0.tar.gz", hash = "sha256:22203e6304402d4a99f2639d0b1c1e03bfb9f461d1cb1596afdc92f2c8920b41"},
-    {file = "aws_cdk.aws_servicediscovery-1.149.0-py3-none-any.whl", hash = "sha256:85ac57dc619043124bf47641f565572d32215fcb38d28b67daf97a41e8b6f456"},
-]
-"aws-cdk.aws-signer" = [
-    {file = "aws-cdk.aws-signer-1.149.0.tar.gz", hash = "sha256:e60890ad3a07aa6bcf683909e82a3649f3a2396e7b07746c34963b512bea9307"},
-    {file = "aws_cdk.aws_signer-1.149.0-py3-none-any.whl", hash = "sha256:1405178bde70ba458f20a0b29f9bd1c94884f9aab3878fb5f0c482e231ef7fc7"},
-]
-"aws-cdk.aws-sns" = [
-    {file = "aws-cdk.aws-sns-1.149.0.tar.gz", hash = "sha256:1b5499b5b99e4210d2eb0520b2e4021e3806da54f6ca0233fd000d177a43bd0d"},
-    {file = "aws_cdk.aws_sns-1.149.0-py3-none-any.whl", hash = "sha256:caddde3d9193183cc42ae1b672a38c7943075efe6a734de669452dff9d55f72a"},
-]
-"aws-cdk.aws-sns-subscriptions" = [
-    {file = "aws-cdk.aws-sns-subscriptions-1.149.0.tar.gz", hash = "sha256:041da8689d3fa405914d3691d585118de0d6eb563b0ba20e0b4df9d9f6276064"},
-    {file = "aws_cdk.aws_sns_subscriptions-1.149.0-py3-none-any.whl", hash = "sha256:5c83bb7cceda31a914952bc3ba0a7d4602ee0977f57c5ff0e903cabcdfcdd3d2"},
-]
-"aws-cdk.aws-sqs" = [
-    {file = "aws-cdk.aws-sqs-1.149.0.tar.gz", hash = "sha256:c867973541b580de7b5515a040f0895638adddc0baf2280cee91eb9ecaddc151"},
-    {file = "aws_cdk.aws_sqs-1.149.0-py3-none-any.whl", hash = "sha256:6da8529a29092016db5a8734f57bc6718cb0073102c0d74cbb1d2dfe7d2aa1f0"},
-]
-"aws-cdk.aws-ssm" = [
-    {file = "aws-cdk.aws-ssm-1.149.0.tar.gz", hash = "sha256:931df66ab7ee79adc5f93822e81353258e7a87966ea171ced582c469f558ba3a"},
-    {file = "aws_cdk.aws_ssm-1.149.0-py3-none-any.whl", hash = "sha256:29c31ecb8c51ddbf5cede38f8806a13681c8cc40262b790b2cd3df9231f4deb9"},
-]
-"aws-cdk.aws-stepfunctions" = [
-    {file = "aws-cdk.aws-stepfunctions-1.149.0.tar.gz", hash = "sha256:3c2a8bc5ec89df9cf7e028120e95620ed41aa2d1fc13efb92c7d343321d84cd4"},
-    {file = "aws_cdk.aws_stepfunctions-1.149.0-py3-none-any.whl", hash = "sha256:ffa1fffb0cea3afb6bfb711e99512ca109cad2def6c0a65c1be9b62c01977e5d"},
-]
-"aws-cdk.aws-stepfunctions-tasks" = [
-    {file = "aws-cdk.aws-stepfunctions-tasks-1.149.0.tar.gz", hash = "sha256:0be49bb155579178f19815699b607090f145a1c6dbd527c41d0a6407520df81c"},
-    {file = "aws_cdk.aws_stepfunctions_tasks-1.149.0-py3-none-any.whl", hash = "sha256:1dcd59af78dffce18413283d0bd756da6996d7718c2b2e95a13558c4c4cd87f8"},
-]
-"aws-cdk.cloud-assembly-schema" = [
-    {file = "aws-cdk.cloud-assembly-schema-1.149.0.tar.gz", hash = "sha256:59d05d051794428a7dbab089a6c637feb7d3ec6c51f7a642d3ec56b045b7ea91"},
-    {file = "aws_cdk.cloud_assembly_schema-1.149.0-py3-none-any.whl", hash = "sha256:9708e3cced60395da611cb1fc19fc14d3c9d46f2451732dd3744d629d0ac3a7d"},
-]
-"aws-cdk.core" = [
-    {file = "aws-cdk.core-1.149.0.tar.gz", hash = "sha256:033ef4ffc37fd0e57aeef7eb21ed2f02bb3395666910eea6db7766bccef3e181"},
-    {file = "aws_cdk.core-1.149.0-py3-none-any.whl", hash = "sha256:872377f62d7321ebbaba335dfd52cc169a36dbb37b3e669c894e6913f9a8b2c2"},
-]
-"aws-cdk.custom-resources" = [
-    {file = "aws-cdk.custom-resources-1.149.0.tar.gz", hash = "sha256:e7478d8b9f4a934ae63e173f5d388a9182c30361fa6a49f7c1396364f35c7020"},
-    {file = "aws_cdk.custom_resources-1.149.0-py3-none-any.whl", hash = "sha256:7003ce5261cca5fb2192b457332ffb45f020d4f530a46a397b19d22439f0ca87"},
-]
-"aws-cdk.cx-api" = [
-    {file = "aws-cdk.cx-api-1.149.0.tar.gz", hash = "sha256:2e6a2b7723ef97cab0aca7ba4070dd5245cf7811f868873910b5411170c8b98a"},
-    {file = "aws_cdk.cx_api-1.149.0-py3-none-any.whl", hash = "sha256:d7e947286cc98f3ca1d448528d4de2956921748f159f38d8c77620f3def71fe2"},
-]
-"aws-cdk.lambda-layer-awscli" = [
-    {file = "aws-cdk.lambda-layer-awscli-1.149.0.tar.gz", hash = "sha256:e50856f517fc1b85f2d186a10b17c3620bc6948f0fdcea2b31380267baa10287"},
-    {file = "aws_cdk.lambda_layer_awscli-1.149.0-py3-none-any.whl", hash = "sha256:cf46c5d49891cd5e679c8b40046d258d41b2968c2d39c1a8f80daff0917e05d5"},
-]
-"aws-cdk.lambda-layer-kubectl" = [
-    {file = "aws-cdk.lambda-layer-kubectl-1.149.0.tar.gz", hash = "sha256:67bfae205aaadc4989f942fa539ab71d17b72979f3a1246fd44b92987ffb0130"},
-    {file = "aws_cdk.lambda_layer_kubectl-1.149.0-py3-none-any.whl", hash = "sha256:cd01557f53a153cba1a5ab96e5eb0bf9160ecd3ee9ba272bd7a8d30f7ab23d32"},
-]
-"aws-cdk.lambda-layer-node-proxy-agent" = [
-    {file = "aws-cdk.lambda-layer-node-proxy-agent-1.149.0.tar.gz", hash = "sha256:c1633183769de5e68a771070b6d04a62d9cdaa3c236c9543e00eea3ead8dbac3"},
-    {file = "aws_cdk.lambda_layer_node_proxy_agent-1.149.0-py3-none-any.whl", hash = "sha256:eadd165e9205e50da074fd8a9d558af446a6300ed32d0fffe69fd76812a2365d"},
-]
-"aws-cdk.region-info" = [
-    {file = "aws-cdk.region-info-1.149.0.tar.gz", hash = "sha256:5fc6113d35fdc37861741f5b1df8b2fca82f42792043716322a0a47ad4d46c08"},
-    {file = "aws_cdk.region_info-1.149.0-py3-none-any.whl", hash = "sha256:d8e25616625e64063656bfee8d4d638c27bdbcae9802c07e8987e7d9b656ca8d"},
+"aws-cdk.aws-lambda-python-alpha" = [
+    {file = "aws-cdk.aws-lambda-python-alpha-2.24.0a0.tar.gz", hash = "sha256:82dd69a3635f2f94668c930f29fec9071bc5fa060037b1be92bdbf131386bf17"},
+    {file = "aws_cdk.aws_lambda_python_alpha-2.24.0a0-py3-none-any.whl", hash = "sha256:055ad182a62d3e48fdef72e6b64a303cf84389f2ec5a6b32c7054ca30fdb8b76"},
 ]
 awscli = [
     {file = "awscli-1.19.53-py2.py3-none-any.whl", hash = "sha256:cebe94ffdaa2dcc8c63eb31844df1f267a01e3c3376d47edbcf927e216438fca"},
@@ -3294,8 +1923,8 @@ boto3 = [
     {file = "boto3-1.17.53.tar.gz", hash = "sha256:1d26f6e7ae3c940cb07119077ac42485dcf99164350da0ab50d0f5ad345800cd"},
 ]
 boto3-stubs = [
-    {file = "boto3-stubs-1.22.12.tar.gz", hash = "sha256:2071ae9c1ba979f9655af2b4fe42e874514a6960036331eeab5ab383b7f993b2"},
-    {file = "boto3_stubs-1.22.12-py3-none-any.whl", hash = "sha256:37b0a25f7a54a30d4325c91e50d39d8d2c1ef33a2df83454443ded76186c87aa"},
+    {file = "boto3-stubs-1.22.13.tar.gz", hash = "sha256:d81608f1be615547dbca346044572d1c07b9b5741ec579da5445429f05c67074"},
+    {file = "boto3_stubs-1.22.13-py3-none-any.whl", hash = "sha256:6460ff29c38481ee244f3f1a3e7e3c0f606e398c449e53e8662204cd69343a41"},
 ]
 botocore = [
     {file = "botocore-1.20.53-py2.py3-none-any.whl", hash = "sha256:d5e70d17b91c9b5867be7d6de0caa7dde9ed789bed62f03ea9b60718dc9350bf"},
@@ -3330,51 +1959,51 @@ colorama = [
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 constructs = [
-    {file = "constructs-3.3.246-py3-none-any.whl", hash = "sha256:e8d0486fa3c5b6a0e4b8d4df2476b6267c68b05532235bdc260b6e9b17dddf84"},
-    {file = "constructs-3.3.246.tar.gz", hash = "sha256:6b0df6a54f95ea2e55134ccd91d51be4d45fa9bb51befaa6fe780d5748724fca"},
+    {file = "constructs-10.1.7-py3-none-any.whl", hash = "sha256:d94ba603f23e30cce98b30067ef95147f32285591d41fdbfbc9ab15fb1c40762"},
+    {file = "constructs-10.1.7.tar.gz", hash = "sha256:e2f8d906c68fac3af878ceceb69d8f76945e8727c875fc7dab81640dad1cb1f2"},
 ]
 coverage = [
-    {file = "coverage-6.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b27d894748475fa858f9597c0ee1d4829f44683f3813633aaf94b19cb5453cf"},
-    {file = "coverage-6.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:37d1141ad6b2466a7b53a22e08fe76994c2d35a5b6b469590424a9953155afac"},
-    {file = "coverage-6.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9987b0354b06d4df0f4d3e0ec1ae76d7ce7cbca9a2f98c25041eb79eec766f1"},
-    {file = "coverage-6.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:26e2deacd414fc2f97dd9f7676ee3eaecd299ca751412d89f40bc01557a6b1b4"},
-    {file = "coverage-6.3.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dd8bafa458b5c7d061540f1ee9f18025a68e2d8471b3e858a9dad47c8d41903"},
-    {file = "coverage-6.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:46191097ebc381fbf89bdce207a6c107ac4ec0890d8d20f3360345ff5976155c"},
-    {file = "coverage-6.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6f89d05e028d274ce4fa1a86887b071ae1755082ef94a6740238cd7a8178804f"},
-    {file = "coverage-6.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:58303469e9a272b4abdb9e302a780072c0633cdcc0165db7eec0f9e32f901e05"},
-    {file = "coverage-6.3.2-cp310-cp310-win32.whl", hash = "sha256:2fea046bfb455510e05be95e879f0e768d45c10c11509e20e06d8fcaa31d9e39"},
-    {file = "coverage-6.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:a2a8b8bcc399edb4347a5ca8b9b87e7524c0967b335fbb08a83c8421489ddee1"},
-    {file = "coverage-6.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f1555ea6d6da108e1999b2463ea1003fe03f29213e459145e70edbaf3e004aaa"},
-    {file = "coverage-6.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5f4e1edcf57ce94e5475fe09e5afa3e3145081318e5fd1a43a6b4539a97e518"},
-    {file = "coverage-6.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7a15dc0a14008f1da3d1ebd44bdda3e357dbabdf5a0b5034d38fcde0b5c234b7"},
-    {file = "coverage-6.3.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21b7745788866028adeb1e0eca3bf1101109e2dc58456cb49d2d9b99a8c516e6"},
-    {file = "coverage-6.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:8ce257cac556cb03be4a248d92ed36904a59a4a5ff55a994e92214cde15c5bad"},
-    {file = "coverage-6.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b0be84e5a6209858a1d3e8d1806c46214e867ce1b0fd32e4ea03f4bd8b2e3359"},
-    {file = "coverage-6.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:acf53bc2cf7282ab9b8ba346746afe703474004d9e566ad164c91a7a59f188a4"},
-    {file = "coverage-6.3.2-cp37-cp37m-win32.whl", hash = "sha256:8bdde1177f2311ee552f47ae6e5aa7750c0e3291ca6b75f71f7ffe1f1dab3dca"},
-    {file = "coverage-6.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b31651d018b23ec463e95cf10070d0b2c548aa950a03d0b559eaa11c7e5a6fa3"},
-    {file = "coverage-6.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:07e6db90cd9686c767dcc593dff16c8c09f9814f5e9c51034066cad3373b914d"},
-    {file = "coverage-6.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2c6dbb42f3ad25760010c45191e9757e7dce981cbfb90e42feef301d71540059"},
-    {file = "coverage-6.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c76aeef1b95aff3905fb2ae2d96e319caca5b76fa41d3470b19d4e4a3a313512"},
-    {file = "coverage-6.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cf5cfcb1521dc3255d845d9dca3ff204b3229401994ef8d1984b32746bb45ca"},
-    {file = "coverage-6.3.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fbbdc8d55990eac1b0919ca69eb5a988a802b854488c34b8f37f3e2025fa90d"},
-    {file = "coverage-6.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ec6bc7fe73a938933d4178c9b23c4e0568e43e220aef9472c4f6044bfc6dd0f0"},
-    {file = "coverage-6.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9baff2a45ae1f17c8078452e9e5962e518eab705e50a0aa8083733ea7d45f3a6"},
-    {file = "coverage-6.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fd9e830e9d8d89b20ab1e5af09b32d33e1a08ef4c4e14411e559556fd788e6b2"},
-    {file = "coverage-6.3.2-cp38-cp38-win32.whl", hash = "sha256:f7331dbf301b7289013175087636bbaf5b2405e57259dd2c42fdcc9fcc47325e"},
-    {file = "coverage-6.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:68353fe7cdf91f109fc7d474461b46e7f1f14e533e911a2a2cbb8b0fc8613cf1"},
-    {file = "coverage-6.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b78e5afb39941572209f71866aa0b206c12f0109835aa0d601e41552f9b3e620"},
-    {file = "coverage-6.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4e21876082ed887baed0146fe222f861b5815455ada3b33b890f4105d806128d"},
-    {file = "coverage-6.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34626a7eee2a3da12af0507780bb51eb52dca0e1751fd1471d0810539cefb536"},
-    {file = "coverage-6.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1ebf730d2381158ecf3dfd4453fbca0613e16eaa547b4170e2450c9707665ce7"},
-    {file = "coverage-6.3.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd6fe30bd519694b356cbfcaca9bd5c1737cddd20778c6a581ae20dc8c04def2"},
-    {file = "coverage-6.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:96f8a1cb43ca1422f36492bebe63312d396491a9165ed3b9231e778d43a7fca4"},
-    {file = "coverage-6.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:dd035edafefee4d573140a76fdc785dc38829fe5a455c4bb12bac8c20cfc3d69"},
-    {file = "coverage-6.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5ca5aeb4344b30d0bec47481536b8ba1181d50dbe783b0e4ad03c95dc1296684"},
-    {file = "coverage-6.3.2-cp39-cp39-win32.whl", hash = "sha256:f5fa5803f47e095d7ad8443d28b01d48c0359484fec1b9d8606d0e3282084bc4"},
-    {file = "coverage-6.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:9548f10d8be799551eb3a9c74bbf2b4934ddb330e08a73320123c07f95cc2d92"},
-    {file = "coverage-6.3.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:18d520c6860515a771708937d2f78f63cc47ab3b80cb78e86573b0a760161faf"},
-    {file = "coverage-6.3.2.tar.gz", hash = "sha256:03e2a7826086b91ef345ff18742ee9fc47a6839ccd517061ef8fa1976e652ce9"},
+    {file = "coverage-6.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df32ee0f4935a101e4b9a5f07b617d884a531ed5666671ff6ac66d2e8e8246d8"},
+    {file = "coverage-6.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:75b5dbffc334e0beb4f6c503fb95e6d422770fd2d1b40a64898ea26d6c02742d"},
+    {file = "coverage-6.3.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:114944e6061b68a801c5da5427b9173a0dd9d32cd5fcc18a13de90352843737d"},
+    {file = "coverage-6.3.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ab88a01cd180b5640ccc9c47232e31924d5f9967ab7edd7e5c91c68eee47a69"},
+    {file = "coverage-6.3.3-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ad8f9068f5972a46d50fe5f32c09d6ee11da69c560fcb1b4c3baea246ca4109b"},
+    {file = "coverage-6.3.3-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4cd696aa712e6cd16898d63cf66139dc70d998f8121ab558f0e1936396dbc579"},
+    {file = "coverage-6.3.3-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c1a9942e282cc9d3ed522cd3e3cab081149b27ea3bda72d6f61f84eaf88c1a63"},
+    {file = "coverage-6.3.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c06455121a089252b5943ea682187a4e0a5cf0a3fb980eb8e7ce394b144430a9"},
+    {file = "coverage-6.3.3-cp310-cp310-win32.whl", hash = "sha256:cb5311d6ccbd22578c80028c5e292a7ab9adb91bd62c1982087fad75abe2e63d"},
+    {file = "coverage-6.3.3-cp310-cp310-win_amd64.whl", hash = "sha256:6d4a6f30f611e657495cc81a07ff7aa8cd949144e7667c5d3e680d73ba7a70e4"},
+    {file = "coverage-6.3.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:79bf405432428e989cad7b8bc60581963238f7645ae8a404f5dce90236cc0293"},
+    {file = "coverage-6.3.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:338c417613f15596af9eb7a39353b60abec9d8ce1080aedba5ecee6a5d85f8d3"},
+    {file = "coverage-6.3.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:db094a6a4ae6329ed322a8973f83630b12715654c197dd392410400a5bfa1a73"},
+    {file = "coverage-6.3.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1414e8b124611bf4df8d77215bd32cba6e3425da8ce9c1f1046149615e3a9a31"},
+    {file = "coverage-6.3.3-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:93b16b08f94c92cab88073ffd185070cdcb29f1b98df8b28e6649145b7f2c90d"},
+    {file = "coverage-6.3.3-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:fbc86ae8cc129c801e7baaafe3addf3c8d49c9c1597c44bdf2d78139707c3c62"},
+    {file = "coverage-6.3.3-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:b5ba058610e8289a07db2a57bce45a1793ec0d3d11db28c047aae2aa1a832572"},
+    {file = "coverage-6.3.3-cp37-cp37m-win32.whl", hash = "sha256:8329635c0781927a2c6ae068461e19674c564e05b86736ab8eb29c420ee7dc20"},
+    {file = "coverage-6.3.3-cp37-cp37m-win_amd64.whl", hash = "sha256:e5af1feee71099ae2e3b086ec04f57f9950e1be9ecf6c420696fea7977b84738"},
+    {file = "coverage-6.3.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e814a4a5a1d95223b08cdb0f4f57029e8eab22ffdbae2f97107aeef28554517e"},
+    {file = "coverage-6.3.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:61f4fbf3633cb0713437291b8848634ea97f89c7e849c2be17a665611e433f53"},
+    {file = "coverage-6.3.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3401b0d2ed9f726fadbfa35102e00d1b3547b73772a1de5508ef3bdbcb36afe7"},
+    {file = "coverage-6.3.3-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8586b177b4407f988731eb7f41967415b2197f35e2a6ee1a9b9b561f6323c8e9"},
+    {file = "coverage-6.3.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:892e7fe32191960da559a14536768a62e83e87bbb867e1b9c643e7e0fbce2579"},
+    {file = "coverage-6.3.3-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:afb03f981fadb5aed1ac6e3dd34f0488e1a0875623d557b6fad09b97a942b38a"},
+    {file = "coverage-6.3.3-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:cbe91bc84be4e5ef0b1480d15c7b18e29c73bdfa33e07d3725da7d18e1b0aff2"},
+    {file = "coverage-6.3.3-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:91502bf27cbd5c83c95cfea291ef387469f2387508645602e1ca0fd8a4ba7548"},
+    {file = "coverage-6.3.3-cp38-cp38-win32.whl", hash = "sha256:c488db059848702aff30aa1d90ef87928d4e72e4f00717343800546fdbff0a94"},
+    {file = "coverage-6.3.3-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6534fcdfb5c503affb6b1130db7b5bfc8a0f77fa34880146f7a5c117987d0"},
+    {file = "coverage-6.3.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:cc692c9ee18f0dd3214843779ba6b275ee4bb9b9a5745ba64265bce911aefd1a"},
+    {file = "coverage-6.3.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:462105283de203df8de58a68c1bb4ba2a8a164097c2379f664fa81d6baf94b81"},
+    {file = "coverage-6.3.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cc972d829ad5ef4d4c5fcabd2bbe2add84ce8236f64ba1c0c72185da3a273130"},
+    {file = "coverage-6.3.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:06f54765cdbce99901871d50fe9f41d58213f18e98b170a30ca34f47de7dd5e8"},
+    {file = "coverage-6.3.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7835f76a081787f0ca62a53504361b3869840a1620049b56d803a8cb3a9eeea3"},
+    {file = "coverage-6.3.3-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:6f5fee77ec3384b934797f1873758f796dfb4f167e1296dc00f8b2e023ce6ee9"},
+    {file = "coverage-6.3.3-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:baa8be8aba3dd1e976e68677be68a960a633a6d44c325757aefaa4d66175050f"},
+    {file = "coverage-6.3.3-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4d06380e777dd6b35ee936f333d55b53dc4a8271036ff884c909cf6e94be8b6c"},
+    {file = "coverage-6.3.3-cp39-cp39-win32.whl", hash = "sha256:f8cabc5fd0091976ab7b020f5708335033e422de25e20ddf9416bdce2b7e07d8"},
+    {file = "coverage-6.3.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c9441d57b0963cf8340268ad62fc83de61f1613034b79c2b1053046af0c5284"},
+    {file = "coverage-6.3.3-pp36.pp37.pp38-none-any.whl", hash = "sha256:d522f1dc49127eab0bfbba4e90fa068ecff0899bbf61bf4065c790ddd6c177fe"},
+    {file = "coverage-6.3.3.tar.gz", hash = "sha256:2781c43bffbbec2b8867376d4d61916f5e9c4cc168232528562a61d1b4b01879"},
 ]
 decorator = [
     {file = "decorator-4.4.2-py2.py3-none-any.whl", hash = "sha256:41fa54c2a0cc4ba648be4fd43cff00aedf5b9465c9bf18d64325bc225f08f760"},
@@ -3465,16 +2094,16 @@ jmespath = [
     {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
 ]
 jsii = [
-    {file = "jsii-1.55.1-py3-none-any.whl", hash = "sha256:1b735bb3ebcebaff02193c8bfbd8760f59bbed32ba38455557fb2ba16f9f97f1"},
-    {file = "jsii-1.55.1.tar.gz", hash = "sha256:251db2cc04a7bcb10e3ec9b1831153b02e920c0c9279ee76d91172d8e2130c44"},
+    {file = "jsii-1.58.0-py3-none-any.whl", hash = "sha256:21830c2dfe5197272dec9bf228d0e8493fdc9ca4501aeec8ce0cc38b2e9dd810"},
+    {file = "jsii-1.58.0.tar.gz", hash = "sha256:e4c3d38e92d837bce132d3fc4b3f2ed4fa9e036cf8aa2ab9be13bb89df1f0441"},
 ]
 jsonpointer = [
     {file = "jsonpointer-2.0-py2.py3-none-any.whl", hash = "sha256:ff379fa021d1b81ab539f5ec467c7745beb1a5671463f9dcc2b2d458bd361c1e"},
     {file = "jsonpointer-2.0.tar.gz", hash = "sha256:c192ba86648e05fdae4f08a17ec25180a9aef5008d973407b581798a83975362"},
 ]
 jsonschema = [
-    {file = "jsonschema-4.4.0-py3-none-any.whl", hash = "sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823"},
-    {file = "jsonschema-4.4.0.tar.gz", hash = "sha256:636694eb41b3535ed608fe04129f26542b59ed99808b4f688aa32dcf55317a83"},
+    {file = "jsonschema-4.5.1-py3-none-any.whl", hash = "sha256:71b5e39324422543546572954ce71c67728922c104902cb7ce252e522235b33f"},
+    {file = "jsonschema-4.5.1.tar.gz", hash = "sha256:7c6d882619340c3347a1bf7315e147e6d3dae439033ae6383d6acb908c101dfc"},
 ]
 junit-xml = [
     {file = "junit-xml-1.8.tar.gz", hash = "sha256:602f1c480a19d64edb452bf7632f76b5f2cb92c1938c6e071dcda8ff9541dc21"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,22 +83,9 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-"aws-cdk.aws-batch" = {version = "*", optional = true}
-"aws-cdk.aws-dynamodb" = {version = "*", optional = true}
-"aws-cdk.aws-ec2" = {version = "*", optional = true}
-"aws-cdk.aws-ecr" = {version = "*", optional = true}
-"aws-cdk.aws-ecr_assets" = {version = "*", optional = true}
-"aws-cdk.aws-ecs" = {version = "*", optional = true}
-"aws-cdk.aws-events" = {version = "*", optional = true}
-"aws-cdk.aws-events-targets" = {version = "*", optional = true}
-"aws-cdk.aws-iam" = {version = "*", optional = true}
-"aws-cdk.aws-lambda" = {version = "*", optional = true}
-"aws-cdk.aws-lambda-event-sources" = {version = "*", optional = true}
-"aws-cdk.aws-lambda-python" = {version = "*", optional = true}
-"aws-cdk.aws-s3" = {version = "*", optional = true}
-"aws-cdk.aws-sns" = {version = "*", optional = true}
-"aws-cdk.aws-stepfunctions" = {version = "*", optional = true}
-"aws-cdk.aws-stepfunctions_tasks" = {version = "*", optional = true}
+"aws-cdk.aws-batch-alpha" = {version = "*", optional = true}
+"aws-cdk.aws-lambda-python-alpha" = {version = "*", optional = true}
+aws-cdk-lib = {version = "*", optional = true}
 awscli = {version = "*", optional = true}
 boto3 = "*"
 cattrs = {version = "*", optional = true}
@@ -142,22 +129,9 @@ extras = ["toml"]
 
 [tool.poetry.extras]
 cdk = [
-    "aws-cdk.aws-batch",
-    "aws-cdk.aws-dynamodb",
-    "aws-cdk.aws-ec2",
-    "aws-cdk.aws-ecr",
-    "aws-cdk.aws-ecr_assets",
-    "aws-cdk.aws-ecs",
-    "aws-cdk.aws-events",
-    "aws-cdk.aws-events-targets",
-    "aws-cdk.aws-iam",
-    "aws-cdk.aws-lambda",
-    "aws-cdk.aws-lambda-event-sources",
-    "aws-cdk.aws-lambda-python",
-    "aws-cdk.aws-s3",
-    "aws-cdk.aws-sns",
-    "aws-cdk.aws-stepfunctions",
-    "aws-cdk.aws-stepfunctions_tasks",
+    "aws-cdk.aws-batch-alpha",
+    "aws-cdk.aws-lambda-python-alpha",
+    "aws-cdk-lib",
     "awscli",
     "cattrs",
 ]


### PR DESCRIPTION
Manual step for this to build:

- [x] [Bootstrap](https://github.com/linz/geostore/actions/workflows/cdk-bootstrap.yml) from this branch - [result](https://github.com/linz/geostore/actions/runs/2328619904)
- [x] Build this branch
- [x] Verify that the build does not report "19836	AWS CDK v1 entering maintenance mode soon" anymore

## Issues

Enables https://github.com/linz/geostore/issues/1262.

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
