### PR TITLE
feat: Use latest extension schemas

### DIFF
--- a/tests/test_get_latest_extension_schema_version.py
+++ b/tests/test_get_latest_extension_schema_version.py
@@ -1,0 +1,5 @@
+from geostore.check_stac_metadata.stac_validators import get_latest_extension_schema_version
+
+
+def should_get_latest_stac_spec_version() -> None:
+    assert get_latest_extension_schema_version("stac-spec") == "1.0.0"


### PR DESCRIPTION
Achieved by finding all the version directories for the extension and
ordering them by version number.

This explicitly only handles `vA.B.C` versions - it does *not* handle
versions like "dev" and "v1.0.0-rc.1". Support for these may need to be
added in the future.

## Issues

Closes #1446.

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
