### PR TITLE
fix: Remove "prod-" prefix from production Lambda endpoints

### DIFF
--- a/infrastructure/constructs/api.py
+++ b/infrastructure/constructs/api.py
@@ -50,7 +50,7 @@ class API(Construct):
 
         datasets_endpoint_lambda = LambdaEndpoint(
             self,
-            "datasets",
+            Resource.DATASETS_ENDPOINT_FUNCTION_NAME.resource_name,
             package_name="datasets",
             env_name=env_name,
             users_role=api_users_role,
@@ -59,7 +59,7 @@ class API(Construct):
 
         dataset_versions_endpoint_lambda = LambdaEndpoint(
             self,
-            "dataset-versions",
+            Resource.DATASET_VERSIONS_ENDPOINT_FUNCTION_NAME.resource_name,
             package_name="dataset_versions",
             env_name=env_name,
             users_role=api_users_role,
@@ -78,7 +78,7 @@ class API(Construct):
 
         import_status_endpoint_lambda = LambdaEndpoint(
             self,
-            "import-status",
+            Resource.IMPORT_STATUS_ENDPOINT_FUNCTION_NAME.resource_name,
             package_name="import_status",
             env_name=env_name,
             users_role=api_users_role,

--- a/infrastructure/constructs/lambda_endpoint.py
+++ b/infrastructure/constructs/lambda_endpoint.py
@@ -25,8 +25,8 @@ class LambdaEndpoint(aws_lambda.Function):
     ):
         super().__init__(
             scope,
-            f"{env_name}-{construct_id}-function",
-            function_name=f"{env_name}-{construct_id}",
+            f"{construct_id}-function",
+            function_name=construct_id,
             handler=f"{BACKEND_DIRECTORY}.{package_name}.entrypoint.lambda_handler",
             runtime=PYTHON_RUNTIME,
             timeout=DEFAULT_LAMBDA_TIMEOUT,


### PR DESCRIPTION
This is one of the few differences between production and all other
environments, so it was never tested.

## Post-deployment steps

- [ ] Verify end user [Lambda names](https://ap-southeast-2.console.aws.amazon.com/lambda/home?region=ap-southeast-2#/functions)

## Issues

Closes https://github.com/linz/geostore/issues/1726.

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
