### PR TITLE
fix: Parse argument values starting with hyphen

### DIFF
--- a/geostore/check_files_checksums/task.py
+++ b/geostore/check_files_checksums/task.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-from argparse import ArgumentParser, Namespace
 from logging import Logger
+from optparse import OptionParser, Values  # pylint: disable=deprecated-module
 
 from linz_logger import get_log
 
@@ -23,17 +23,23 @@ S3_ROLE_ARN_ARGUMENT = "--s3-role-arn"
 LOGGER: Logger = get_log()
 
 
-def parse_arguments() -> Namespace:
-    argument_parser = ArgumentParser()
-    argument_parser.add_argument(DATASET_ID_ARGUMENT, required=True)
-    argument_parser.add_argument(NEW_VERSION_ID_ARGUMENT, required=True)
-    argument_parser.add_argument(CURRENT_VERSION_ID_ARGUMENT, required=True)
-    argument_parser.add_argument(DATASET_PREFIX_ARGUMENT, required=True)
-    argument_parser.add_argument(FIRST_ITEM_ARGUMENT, type=int, required=True)
-    argument_parser.add_argument(RESULTS_TABLE_NAME_ARGUMENT, required=True)
-    argument_parser.add_argument(ASSETS_TABLE_NAME_ARGUMENT, required=True)
-    argument_parser.add_argument(S3_ROLE_ARN_ARGUMENT, required=True)
-    return argument_parser.parse_args()
+def parse_arguments() -> Values:
+    parser = OptionParser()
+    parser.add_option(DATASET_ID_ARGUMENT)
+    parser.add_option(NEW_VERSION_ID_ARGUMENT)
+    parser.add_option(CURRENT_VERSION_ID_ARGUMENT)
+    parser.add_option(DATASET_PREFIX_ARGUMENT)
+    parser.add_option(FIRST_ITEM_ARGUMENT, type=int)
+    parser.add_option(RESULTS_TABLE_NAME_ARGUMENT)
+    parser.add_option(ASSETS_TABLE_NAME_ARGUMENT)
+    parser.add_option(S3_ROLE_ARN_ARGUMENT)
+    (options, _args) = parser.parse_args()
+
+    for option in parser.option_list:
+        if option.dest is not None:
+            assert hasattr(options, option.dest)
+
+    return options
 
 
 def main() -> None:


### PR DESCRIPTION
It is not possible to configure AWS Batch job definition parameters to
pass `--key=Ref::some_argument`
<https://docs.aws.amazon.com/batch/latest/userguide/job_definition_parameters.html#parameters=>,
and `argparse` has a long-standing issue re. not being able to handle
`--key -value`-type key/value pairs
<python/cpython#53580>. The only known
workaround is to use the deprecated `optparse` module.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
