### PR TITLE
refactor: Speed up CDK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Destroy AWS stacks used for testing
         run: |
-          poetry run cdk destroy --force --all
+          aws cloudformation delete-stack --stack-name ci${GITHUB_RUN_ID}-geostore
         if: always()
 
   build-nix-shell:


### PR DESCRIPTION
This pull request optimises Geostore CDK deployment time in GitHub Actions workflow by calling `aws cloudformation delete-stack` rather than `cdk destroy`

Running `cdk destroy` causes cdk to parse through the stack again before attempting to tear it down. It waits for the stack to be completely destroyed before finishing the workflow. ` aws cloudformation delete-stack` is a simple api call that doesn't wait for a response. It allows the call to be made to aws to terminate the stack. This shaves about ~5 to 6 minutes off the workflow runtime. 