### PR TITLE
fix: Skip test for .md changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Pull request
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - '**.md'
 
 jobs:
   linter:


### PR DESCRIPTION
No need to trigger long-running test workflow for .md changes.

[Reference](https://stackoverflow.com/questions/62968897/is-it-possible-to-not-run-github-action-for-readme-updates)