### PR TITLE
fix: Use UTC datetimes

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -198,6 +198,21 @@ This document is meant to give general hints for code reviewers. It should not b
 complete set of things to consider, and should not include anything which is currently being
 validated automatically.
 
+#### Time zones
+
+-  Only use time zone-aware datetimes.
+
+   Bad examples:
+   [`datetime.utcnow()` and `datetime.utcfromtimestamp()` return datetimes without a time zone](https://blog.ganssle.io/articles/2019/11/utcnow.html),
+   despite `utc` in the name.
+
+   Good examples: `datetime.now(tz=timezone.utc)` and
+   `datetime.fromtimestamp(timestamp, tz=timezone.utc)`.
+
+   Rationale: When doing anything with time zone-naive datetimes they are considered to be in the
+   same time zone as the local machine clock, which is not what you'd ever want when programming for
+   another system.
+
 #### Dockerfiles
 
 -  Don't pin `apt` package versions.

--- a/geostore/dataset_versions/create.py
+++ b/geostore/dataset_versions/create.py
@@ -1,5 +1,5 @@
 """Dataset versions handler function."""
-from datetime import datetime
+from datetime import datetime, timezone
 from http import HTTPStatus
 from json import dumps
 from logging import Logger
@@ -91,7 +91,7 @@ def create_dataset_version(body: JsonObject) -> JsonObject:
         )
         return error_response(HTTPStatus.NOT_FOUND, f"dataset '{dataset_id}' could not be found")
 
-    now = datetime.fromisoformat(body.get(NOW_KEY, datetime.utcnow().isoformat()))
+    now = datetime.fromisoformat(body.get(NOW_KEY, datetime.now(tz=timezone.utc).isoformat()))
     dataset_version_id = human_readable_ulid(from_timestamp(now))
     current_dataset_version = dataset.current_dataset_version or CURRENT_VERSION_EMPTY_VALUE
 


### PR DESCRIPTION
`utcnow` returns a datetime without a time zone, which makes it risky for any kind of use. We should avoid it and `utcfromtimestamp`. See <https://blog.ganssle.io/articles/2019/11/utcnow.html> for details.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](https://github.com/linz/geostore/blob/master/CODING.md#Checklist)
