### PR TITLE
feat: Remove dependabot commits from changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot


### PR DESCRIPTION
Changelog typically outlines what has changed since the last release. We can GitHub to automatically generate release notes every time we do a release; however, this is often filled with commits created by dependabot (bump package version). This PR excludes dependabot commits from future release notes. 

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference
https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes

