### PR TITLE
fix: Checkout pull request HEAD commit instead of merge commit

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,14 @@ jobs:
 
     steps:
       - name: Checkout repository
+        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v3.1.0
+
+      - name: Checkout repository
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.1.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Get configuration
         run: |

--- a/.github/workflows/package-cli.yml
+++ b/.github/workflows/package-cli.yml
@@ -10,9 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out repository
+      - name: Checkout repository
+        if: ${{ github.event_name == 'push' }}
         uses: actions/checkout@v3.1.0
         with:
+          submodules: 'true'
+
+      - name: Checkout repository
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3.1.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: 'true'
 
       - id: python-version

--- a/.github/workflows/prod-upgrade-deploy-test.yml
+++ b/.github/workflows/prod-upgrade-deploy-test.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Check out repository
+      - name: Checkout repository
         uses: actions/checkout@v3.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/prod-upgrade-deploy-test.yml
+++ b/.github/workflows/prod-upgrade-deploy-test.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.1.0
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: true
 
       - name: Get Oidc deploy role arn
@@ -117,7 +118,7 @@ jobs:
       - name: Checkout to current pull request version
         uses: actions/checkout@v3.1.0
         with:
-          ref: ${{ env.GITHUB_SHA }}
+          ref: ${{ github.event.pull_request.head.sha }}
           clean: false
           submodules: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
   linter:
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out repository
+      - name: Checkout repository
         uses: actions/checkout@v3.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
@@ -55,7 +55,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Check out repository
+      - name: Checkout repository
         uses: actions/checkout@v3.1.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.1.0
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # this is to enable gitlint to check all PR commit messages
           submodules: 'true'
 
@@ -57,6 +58,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v3.1.0
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: 'true'
 
       - id: node-version
@@ -175,6 +177,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3.1.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: cachix/install-nix-action@v18
       - uses: cachix/cachix-action@v12


### PR DESCRIPTION
By default, GitHub Action will checkout the merge commit created for the pull request rather than the actual commit used to create the pull request. There is a slim but non zero chance that this could cause some flaky tests. This PR is to get GitHub Actions to checkout pull request HEAD commit instead of merge commit.

**Note:** This only applies to `pull_request` as per [GitHub documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request). Since geostore's workflow can be triggered by different events, a conditional step is added to ensure this change only applies to `pull_request`. 

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
https://github.com/actions/checkout/issues/261
https://github.com/actions/checkout#Checkout-pull-request-HEAD-commit-instead-of-merge-commit

