### PR TITLE
feat: Log Step Function State Machine events

### DIFF
--- a/infrastructure/constructs/processing.py
+++ b/infrastructure/constructs/processing.py
@@ -4,6 +4,7 @@ from aws_cdk import (
     aws_dynamodb,
     aws_iam,
     aws_lambda_python_alpha,
+    aws_logs,
     aws_s3,
     aws_sqs,
     aws_ssm,
@@ -440,6 +441,8 @@ class Processing(Construct):
 
         ############################################################################################
         # STATE MACHINE
+
+        log_group = aws_logs.LogGroup(self, "state machine logs")
         dataset_version_creation_definition = (
             check_stac_metadata_task.add_catch(
                 errors=[Errors.TASKS_FAILED],
@@ -522,6 +525,9 @@ class Processing(Construct):
             self,
             f"{env_name}-dataset-version-creation",
             definition=dataset_version_creation_definition,
+            logs=aws_stepfunctions.LogOptions(
+                destination=log_group, level=aws_stepfunctions.LogLevel.ALL
+            ),
         )
 
         self.state_machine_parameter = aws_ssm.StringParameter(


### PR DESCRIPTION
We should probably be logging Step Function State Machine events to CloudWatch. This would help with troubleshooting. 
This complies with [AwsSolutions-SF1](https://github.com/cdklabs/cdk-nag/blob/main/RULES.md). 

Example log snippet:
```
{
    "id": "4",
    "type": "LambdaFunctionStarted",
    "details": {},
    "previous_event_id": "3",
    "event_timestamp": "1668385713883",
    "execution_arn": "arn:aws:states:ap-southeast-2:12345:execution:processinggeostoredatasetversioncreation65D71092-W9Bi3T8DiGui:2022-11-14T00-28-33-438Z_59Z1PGC394K1FR4H"
}

{
    "id": "5",
    "type": "LambdaFunctionFailed",
    "details": {
        "cause": "{\"errorMessage\": \"\", \"errorType\": \"InvalidSTACRootTypeError\", \"requestId\": \"ef0b96d2-560b-44fc-9b67-b69f4800b735\", \"stackTrace\": [\"  File \\\"/var/task/geostore/check_stac_metadata/task.py\\\", line 102, in lambda_handler\\n    validator.run(event[METADATA_URL_KEY])\\n\", \"  File \\\"/var/task/geostore/check_stac_metadata/utils.py\\\", line 155, in run\\n    raise InvalidSTACRootTypeError()\\n\"]}",
        "error": "InvalidSTACRootTypeError"
    },
    "previous_event_id": "4",
    "event_timestamp": "1668385717164",
    "execution_arn": "arn:aws:states:ap-southeast-2:12345:execution:processinggeostoredatasetversioncreation65D71092-W9Bi3T8DiGui:2022-11-14T00-28-33-438Z_59Z1PGC394K1FR4H"
}
```

