### PR TITLE
feat: Ensure only one GitHub action workflow is running

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   CodeQL-Build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/package-cli.yml
+++ b/.github/workflows/package-cli.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/prod-upgrade-deploy-test.yml
+++ b/.github/workflows/prod-upgrade-deploy-test.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [labeled, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   test-prod-upgrade:
     if:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   linter:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Geostore CI takes a while to complete. In cases where a new commit is pushed to an existing pull request branch before the previous GitHub action workflow completes, a new workflow is triggered; leaving the old workflow to run its course even though it is no longer relevant (in most cases). This PR limits workflow concurrency by cancelling previous workflow.

This resolves #2290 

References:
https://docs.github.com/en/actions/using-jobs/using-concurrency
https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre/72408109#72408109