### PR TITLE
feat: Delete CloudWatch Log Groups over a week old

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,6 +176,13 @@ jobs:
           aws cloudformation delete-stack --stack-name ci${GITHUB_RUN_ID}-geostore
         if: always()
 
+      - name: Delete CloudWatch Log Groups over a week old
+        run: |
+          aws logs describe-log-groups --log-group-name-prefix='/aws/lambda/ci' --output=text --no-paginate | \
+          awk -v date="$(($(date --date='1 week ago' +%s)*1000))" '{ if ($3 < date) print $4}' | \
+          xargs --no-run-if-empty --verbose -I{} aws logs delete-log-group --log-group-name={}
+        if: always()
+
   build-nix-shell:
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
There is no mechanism in place to clean up CloudWatch Log Groups created by Geostore. While the logs itself can be set to expire, the Log Groups are kept forever. This presents a problem in CI. 

There isn't an elegant way to delete log groups within CDK on stack teardown currently (this may change in the future). 

This PR runs `aws logs delete-log-group` command at the end of the CI to cull log groups older than 1 week old (from previous CI runs). **This is a temporary work around until a better solution is found.** 

Note: A `--no-paginate` option is added to limit the number of queries (~50). This prevents rate limiting as well as stops a potentially endless number of results being returned by AWS (which would result in a very log running workflow). This means only a maximum number of 50 log groups are removed each workflow run.


A workaround / partial fix to #2319 