### PR TITLE
fix: Delete Cloudwatch log groups race condition

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -180,7 +180,8 @@ jobs:
         run: |
           aws logs describe-log-groups --log-group-name-prefix='/aws/lambda/ci' --output=text --no-paginate | \
           awk -v date="$(($(date --date='1 week ago' +%s)*1000))" '{ if ($3 < date) print $4}' | \
-          xargs --no-run-if-empty --verbose -I{} aws logs delete-log-group --log-group-name={}
+          xargs --no-run-if-empty --verbose -I{} aws logs delete-log-group --log-group-name={} || \
+          [[ $? -eq 123 ]]
         if: always()
 
   build-nix-shell:


### PR DESCRIPTION
It is possible that the `delete-log-group` command to gets into a race condition when more than one CI runs at the same time (i.e. it tries to delete the same log group that another CI has just deleted moments ago). This causes `xargs` to throw a `123` exit code, which, in turn causes GitHub actions to fail. Ignoring this exit code is one way to get around this problem as a workaround. It should be noted that this implementation prevents other `xargs` errors with the same exit code from being raised.
