### PR TITLE
fix: Exclude .lock files from TOML auto-formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,6 +55,7 @@ repos:
         language: system
         stages: [commit]
         types: [toml]
+        exclude: ^.*\.lock
 
       - id: pylint
         name: pylint


### PR DESCRIPTION
`poetry.lock` is now correctly detected as a TOML file by `pretty-format-toml`, which means all the Dependabot PRs are failing.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](https://github.com/linz/geostore/blob/master/CODING.md#Checklist)
