### PR TITLE
refactor: Use class variable instead of lru_cache

### DIFF
--- a/infrastructure/application_stack.py
+++ b/infrastructure/application_stack.py
@@ -1,9 +1,12 @@
+import atexit
+import shutil
 from os import environ
 
 import constructs
 from aws_cdk import Environment, Stack, aws_iam
 
 from geostore.environment import environment_name
+from infrastructure.constructs.bundled_code import LambdaPackaging
 
 from .constructs.api import API
 from .constructs.lambda_layers import LambdaLayers
@@ -103,3 +106,8 @@ class Application(Stack):
             OpenTopography(
                 self, "opentopography", env_name=env_name, storage_bucket=storage.storage_bucket
             )
+
+        # Remove temp lambda packaging directory at exit to purge pip packages
+        # Reusing pip packages would speed things up, but also makes things
+        # harder to troubleshoot when there is a change in one of the Python packages
+        atexit.register(lambda: shutil.rmtree(LambdaPackaging.directory))

--- a/infrastructure/constructs/bundled_code.py
+++ b/infrastructure/constructs/bundled_code.py
@@ -1,7 +1,5 @@
-import atexit
-import shutil
 import tempfile
-from functools import lru_cache
+from dataclasses import dataclass
 from re import sub
 from subprocess import check_call, check_output
 from sys import executable
@@ -11,13 +9,6 @@ from aws_cdk import BundlingOptions, aws_lambda
 
 from .backend import BACKEND_DIRECTORY
 from .lambda_config import PYTHON_RUNTIME
-
-
-@lru_cache
-def lambda_packaging_dir() -> str:
-    packaging_dir = tempfile.mkdtemp(dir=BACKEND_DIRECTORY, prefix=".lambda_out_")
-    atexit.register(lambda: shutil.rmtree(packaging_dir))
-    return packaging_dir
 
 
 def poetry_export_extras(lambda_directory: str) -> List[str]:
@@ -35,9 +26,7 @@ def poetry_export_extras(lambda_directory: str) -> List[str]:
     return export_extras.decode("utf-8").splitlines()
 
 
-def pip_install_requirements(
-    lambda_directory: str, packaging_directory: str, export_extras: List[str]
-) -> None:
+def pip_install_requirements(lambda_directory: str, export_extras: List[str]) -> None:
     # Documentation recommend against calling pip internal api; rather, via command line
     # https://pip.pypa.io/en/latest/user_guide/#using-pip-from-your-program
 
@@ -49,24 +38,28 @@ def pip_install_requirements(
             "install",
             "--no-deps",
             "--quiet",
-            f"--cache-dir={packaging_directory}/cache",
-            f"--target={packaging_directory}/{lambda_directory}",
+            f"--cache-dir={LambdaPackaging.directory}/cache",
+            f"--target={LambdaPackaging.directory}/{lambda_directory}",
             *export_extras,
         ]
     )
 
 
+@dataclass
+class LambdaPackaging:
+    directory = tempfile.mkdtemp(dir=BACKEND_DIRECTORY, prefix=".lambda_out_")
+
+
 def bundled_code(lambda_directory: str) -> aws_lambda.Code:
-    packaging_directory = lambda_packaging_dir()
     export_extras = poetry_export_extras(lambda_directory)
-    pip_install_requirements(lambda_directory, packaging_directory, export_extras)
+    pip_install_requirements(lambda_directory, export_extras)
     bundling_options = BundlingOptions(
         image=PYTHON_RUNTIME.bundling_image,  # pylint:disable=no-member
         command=[
             "bash",
             "-c",
             f"""mkdir --parents /asset-output/geostore/{lambda_directory} && \
-                cp --archive --update {packaging_directory}/{lambda_directory}/* /asset-output/ && \
+                cp --archive --update {LambdaPackaging.directory}/{lambda_directory}/* /asset-output/ && \
                 cp --archive --update /asset-input/geostore/*.py /asset-output/geostore/ && \
                 cp --archive --update /asset-input/geostore/{lambda_directory} /asset-output/geostore/""",  # pylint: disable=line-too-long
         ],


### PR DESCRIPTION
`lru_cache` is a bit of a hacky workaround to prevent values from being updated within the context of setting up a `lambda_packaging_dir` using `mkdtemp` (that is persistent throughout a particular run). This isn't how it is intended to be used. A class variable would provide the same outcome whilst keeping the code a bit tidier.
