### PR TITLE
chore: Delete reference to bundle.bash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ classifiers = [
 exclude = [
     "geostore/*.txt",
     "geostore/Dockerfile",
-    "geostore/bundle.bash",
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
This was missed in PR #2516