### PR TITLE
feat: Cache pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-${{ secrets.CACHE_SEED }}-${{ env.PYTHON_VERSION }}-
 
+      - name: Cache pre-commit
+        uses: actions/cache@v3.2.3
+        with:
+          path: ~/.cache/pre-commit
+          key: ${{ secrets.CACHE_SEED }}-${{ hashFiles('.pre-commit-config.yaml') }}
+
       - name: Install Python dependencies
         run: |
           python -m pip install --requirement=geostore/pip.txt


### PR DESCRIPTION
Cuts ~2 minutes off of the linting step (https://github.com/linz/geostore/actions/runs/3906625303/jobs/6675012868 vs https://github.com/linz/geostore/actions/runs/3906625303/jobs/6675354730).

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](https://github.com/linz/geostore/blob/master/CODING.md#Checklist)
